### PR TITLE
LIBXML_PARSEHUGE option set

### DIFF
--- a/trunk/web/admin/problem_import_xml.php
+++ b/trunk/web/admin/problem_import_xml.php
@@ -78,7 +78,7 @@ if ($_FILES ["fps"] ["error"] > 0) {
 	//$xmlDoc = new DOMDocument ();
 	//$xmlDoc->load ( $tempfile );
 	//$xmlcontent=file_get_contents($tempfile );
-	$xmlDoc=simplexml_load_file($tempfile);
+	$xmlDoc=simplexml_load_file($tempfile, 'SimpleXMLElement', LIBXML_PARSEHUGE);
 	$searchNodes = $xmlDoc->xpath ( "/fps/item" );
 	$spid=0;
 	foreach($searchNodes as $searchNode) {


### PR DESCRIPTION
No LIBXML_PARSEHUGE flag causes truncation of problem set XML files (size > 10MB seemingly) under Ubuntu 14.04-server 32bit.
