### PR TITLE
Update java0.policy

### DIFF
--- a/trunk/install/java0.policy
+++ b/trunk/install/java0.policy
@@ -1,5 +1,4 @@
 
 grant {
-    permission java.io.FilePermission "./*", "read";
-    permission java.io.FilePermission "./*", "write";
+    permission java.io.FilePermission "./-", "read, write";
 };


### PR DESCRIPTION
Maybe fix [Only openjdk works](https://github.com/zhblue/hustoj/blame/0800468bca8ef7be2e5ec7d245c496638e4f0069/wiki/CentOSx86_64.wiki#L10)
See [Java FilePermission](https://docs.oracle.com/javase/7/docs/api/java/io/FilePermission.html)