### PR TITLE
Add $OJ_ON_SITE_TEAM_TOTAL 

### DIFF
--- a/trunk/web/contestrank3.php
+++ b/trunk/web/contestrank3.php
@@ -235,7 +235,10 @@ if (isset($_GET['type'])&&$_GET['type']=='json') {
 	$start_time_str = date("Y-m-d H:i:s",$start_time);
 	$lock_time_str = date("Y-m-d H:i:s",$lock);
 $problem_num = pdo_query("select count(distinct problem_id ) from contest_problem where contest_id=?",$cid)[0][0];
-$team_num=pdo_query("select count(distinct user_id ) from solution where contest_id=?",$cid)[0][0];
+if($OJ_ON_SITE_TEAM_TOTAL!=0)
+ $team_num=$OJ_ON_SITE_TEAM_TOTAL;
+else
+ $team_num=pdo_query("select count(distinct user_id ) from solution where contest_id=?",$cid)[0][0];
 $gold_num=intval($team_num*0.05);
 $silver_num=intval($team_num*0.15);
 $bronze_num=intval($team_num*0.20);

--- a/trunk/web/include/db_info.inc.php
+++ b/trunk/web/include/db_info.inc.php
@@ -54,7 +54,9 @@ static  $OJ_ENCODE_SUBMIT=false; //是否启用base64编码提交的功能，用
 
 //static  $OJ_EXAM_CONTEST_ID=1000; // 启用考试状态，填写考试比赛ID
 //static  $OJ_ON_SITE_CONTEST_ID=1000; //启用现场赛状态，填写现场赛比赛ID
-
+//$OJ_ON_SITE_TEAM_TOTAL用于计算奖牌比例的有效参赛队伍总数，此总数不含打星队伍。
+//0表示根据榜单上的出现的队伍总数计算，非0即采用此值计算。
+static $OJ_ON_SITE_TEAM_TOTAL=0;
 static $OJ_OPENID_PWD = '8a367fe87b1e406ea8e94d7d508dcf01';
 
 /* weibo config here */

--- a/trunk/web/template/bs3/contestrank-oi.php
+++ b/trunk/web/template/bs3/contestrank-oi.php
@@ -156,7 +156,14 @@ function metal(){
 var tb=window.document.getElementById('rank');
 var rows=tb.rows;
 try{
-var total=getTotal(rows);
+  <?php 
+    //若有队伍从未进行过任何提交，数据库solution表里不会有数据，榜单上该队伍不存在，总rows数量不等于报名参赛队伍数量，奖牌比例的计算会出错
+    //解决办法：可以为现场赛采用人为设定有效参赛队伍数$OJ_ON_SITE_TEAM_TOTAL，值为0时则采用榜单计算。详情见db_info.inc.php
+    if($OJ_ON_SITE_TEAM_TOTAL!=0)
+      echo "var total=".$OJ_ON_SITE_TEAM_TOTAL.";";
+    else
+      echo "var total=getTotal(rows);";
+  ?>
 //alert(total);
 for(var i=1;i<rows.length;i++){
 var cell=rows[i].cells[0];

--- a/trunk/web/template/bs3/contestrank.php
+++ b/trunk/web/template/bs3/contestrank.php
@@ -158,7 +158,14 @@ function metal(){
 var tb=window.document.getElementById('rank');
 var rows=tb.rows;
 try{
-var total=getTotal(rows);
+  <?php 
+    //若有队伍从未进行过任何提交，数据库solution表里不会有数据，榜单上该队伍不存在，总rows数量不等于报名参赛队伍数量，奖牌比例的计算会出错
+    //解决办法：可以为现场赛采用人为设定有效参赛队伍数$OJ_ON_SITE_TEAM_TOTAL，值为0时则采用榜单计算。详情见db_info.inc.php
+    if($OJ_ON_SITE_TEAM_TOTAL!=0)
+      echo "var total=".$OJ_ON_SITE_TEAM_TOTAL.";";
+    else
+      echo "var total=getTotal(rows);";
+  ?>
 //alert(total);
 for(var i=1;i<rows.length;i++){
 var cell=rows[i].cells[0];


### PR DESCRIPTION
若有队伍从未进行过任何提交，数据库solution表里不会有数据，榜单上该队伍不存在，总rows数量不等于报名参赛队伍数量，奖牌比例的计算会出错
解决办法（临时，本PR采用）：可以为现场赛采用人为设定有效参赛队伍数$OJ_ON_SITE_TEAM_TOTAL，值为0时则采用榜单计算。详情见db_info.inc.php 
解决办法（永久，TODO）：为contest表添加一列存储有效参赛队伍数，添加比赛时设定。