### PR TITLE
Update trunk/install/install-centos7.sh

### DIFF
--- a/trunk/install/install-centos7.sh
+++ b/trunk/install/install-centos7.sh
@@ -113,10 +113,9 @@ yum -y install mono
 ln -s /usr/bin/mcs /usr/bin/gmcs
 
 #free pascal
-wget https://downloads.sourceforge.net/project/freepascal/Linux/3.0.4/fpc-3.0.4.x86_64-linux.tar
-tar xf fpc-3.0.4.x86_64-linux.tar
-cd fpc-3.0.4.x86_64-linux
-echo -e "\n\n\n\n\n\n\n\n\n\n"|sh install.sh
+wget https://download.sourceforge.net/project/freepascal/Linux/3.0.4/fpc-3.0.4-1.x86_64.rpm
+rpm -ivh fpc-3.0.4-1.x86_64.rpm
+rm -rf fpc-3.0.4-1.x86_64.rpm
 
 reset
 echo "Remember your database account for HUST Online Judge:"

--- a/trunk/install/install-centos7.sh
+++ b/trunk/install/install-centos7.sh
@@ -75,8 +75,14 @@ systemctl enable php-fpm.service
 # startup mariadb.service when booting.
 systemctl enable mariadb.service
 
-# set selinux bool flag to avoid 'access denied' error.
-setsebool -P httpd_read_user_content 1
+# set selinux content .
+# to avoid 'access denied' and cannot upload .
+# not ensure there has no other problems .
+semanage fcontent -a -t httpd_sys_content_t /home/judge/web
+semanage fcontent -a -t httpd_sys_content_t /home/judge/src
+
+# If you want to unify HTTPD handling of all content files, you must turn on the httpd_unified boolean.
+setsebool -P httpd_unified 1
 
 chmod 755 /home/judge
 chown apache -R /home/judge/src/web/

--- a/trunk/install/install-centos7.sh
+++ b/trunk/install/install-centos7.sh
@@ -97,6 +97,7 @@ chmod +x make.sh
 if grep "/usr/bin/judged" /etc/rc.local ; then
 	echo "auto start judged added!"
 else
+	chmod +x /etc/rc.d/rc.local
 	sed -i "s/exit 0//g" /etc/rc.local
 	echo "/usr/bin/judged" >> /etc/rc.local
 	echo "exit 0" >> /etc/rc.local

--- a/trunk/install/install-centos7.sh
+++ b/trunk/install/install-centos7.sh
@@ -98,9 +98,9 @@ if grep "/usr/bin/judged" /etc/rc.local ; then
 	echo "auto start judged added!"
 else
 	chmod +x /etc/rc.d/rc.local
-	sed -i "s/exit 0//g" /etc/rc.local
-	echo "/usr/bin/judged" >> /etc/rc.local
-	echo "exit 0" >> /etc/rc.local
+	sed -i "s/exit 0//g" /etc/rc.d/rc.local
+	echo "/usr/bin/judged" >> /etc/rc.d/rc.local
+	echo "exit 0" >> /etc/rc.d/rc.local
 	
 fi
 /usr/bin/judged


### PR DESCRIPTION
Fix some access denied problems use safer method without closing selinux.
Use fpc.rpm instead of fpc.tar in order to download faster(27M/54M) and updatable.
Fix `judged not start when booting` bug, because `/etc/rc.local` are not soft link of `/etc/rc.d/rc.local` any more on my Centos7.5_1804 machine.