### PR TITLE
Backup/Restore Shell Script for Centos7

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ https://www.youtube.com/watch?v=hRap7ettUWc
 
 大部分功能和选项的开关和参数调整都在配置文件中，安装后几个重要配置文件的位置如下：
 
-    /home/judge/etc/judge.conf        判题judged/judge_client
-    /home/judge/src/web/include/db_info.inc.php   Web
-    /etc/php5/fpm/php.ini 或 /etc/php7.0/fpm/php.ini 或 /etc/php.ini (in Centos7)   php
-    /etc/nginx/sites-enabled/default 或 /etc/nginx/nginx.conf (in Centos7)               nginx
+    /home/judge/etc/judge.conf                                                      判题judged/judge_client
+    /home/judge/src/web/include/db_info.inc.php                                     Web
+    /etc/php5/fpm/php.ini 或 /etc/php7.0/fpm/php.ini 或 /etc/php.ini (in Centos7)    php
+    /etc/nginx/sites-enabled/default 或 /etc/nginx/nginx.conf (in Centos7)          nginx
     
 如果用户量比较大，报50x错误,可能需要修改/etc/nginx/nginx.conf中的设置：
 ```

--- a/trunk/install/backup.centos7.sh
+++ b/trunk/install/backup.centos7.sh
@@ -27,7 +27,7 @@ echo "backup web files"
 cp -r /home/judge/src/web /home/judge/backup/${cdate}/src/web
 
 echo "Create backup archive"
-tar -zcvf /home/judge/backup/${cdate}.tar.gz -C /home/judge/backup/${cdate} data etc src
+tar -zcvf /home/judge/backup/${cdate}.tar.gz -C /home/judge/backup/${cdate} jol.sql data etc src
 
 echo "clean backup temp files"
 rm -rf /home/judge/backup/${cdate}

--- a/trunk/install/backup.centos7.sh
+++ b/trunk/install/backup.centos7.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/bash
+
+# current timestamp
+cdate=`date '+%Y-%m-%d-%H-%M-%S'`
+
+mkdir /home/judge/backup
+mkdir /home/judge/backup/${cdate}
+mkdir /home/judge/backup/${cdate}/etc
+mkdir /home/judge/backup/${cdate}/src
+
+# Get database password
+OJ_PASSWORD=`cat /home/judge/etc/judge.conf | grep OJ_PASSWORD`
+DB_USERNAME=root
+DB_PASSWORD=`echo ${OJ_PASSWORD:12}`
+
+echo "dump mysql/mariadb database"
+mysqldump -u${DB_USERNAME} -p${DB_PASSWORD} -B jol > /home/judge/backup/${cdate}/jol.sql
+
+echo "backup data directory"
+cp -r /home/judge/data /home/judge/backup/${cdate}/data
+
+echo "backup config files"
+cp /home/judge/etc/java0.policy /home/judge/backup/${cdate}/etc/java0.policy
+cp /home/judge/etc/judge.conf   /home/judge/backup/${cdate}/etc/judge.conf
+
+echo "backup web files"
+cp -r /home/judge/src/web /home/judge/backup/${cdate}/src/web
+
+echo "Create backup archive"
+tar -zcvf /home/judge/backup/${cdate}.tar.gz -C /home/judge/backup/${cdate} data etc src
+
+echo "clean backup temp files"
+rm -rf /home/judge/backup/${cdate}

--- a/trunk/install/backup.centos7.sh
+++ b/trunk/install/backup.centos7.sh
@@ -9,8 +9,9 @@ mkdir /home/judge/backup/${cdate}/etc
 mkdir /home/judge/backup/${cdate}/src
 
 # Get database password
+OJ_USERNAME=`cat /home/judge/etc/judge.conf | greo OJ_USER_NAME`
 OJ_PASSWORD=`cat /home/judge/etc/judge.conf | grep OJ_PASSWORD`
-DB_USERNAME=root
+DB_USERNAME=`echo ${OJ_USERNAME:13}`
 DB_PASSWORD=`echo ${OJ_PASSWORD:12}`
 
 echo "dump mysql/mariadb database"

--- a/trunk/install/restore.centos7.sh
+++ b/trunk/install/restore.centos7.sh
@@ -31,7 +31,7 @@ rm -rf /home/judge/src/web
 mkdir /home/judge/backup/temp
 
 # start restore
-tar -xvf /home/judge/backup/${archive} -C /home/judge/backup/temp
+tar -xf /home/judge/backup/${archive} -C /home/judge/backup/temp
 
 # restore database
 echo "restore database"
@@ -50,9 +50,9 @@ cp -r /home/judge/backup/temp/src/web /home/judge/src/web
 
 # adjustment config file
 CPU=`cat /proc/cpuinfo| grep "processor"| wc -l`
-cdbusername = `cat /home/judge/etc/judge.conf | grep OJ_USER_NAME`
-cdbpassword = `cat /home/judge/etc/judge.conf | grep OJ_PASSWORD`
-ccpu        = `cat /home/judge/etc/judge.conf | grep OJ_RUNNING`
+cdbusername=`cat /home/judge/etc/judge.conf | grep OJ_USER_NAME`
+cdbpassword=`cat /home/judge/etc/judge.conf | grep OJ_PASSWORD`
+ccpu=`cat /home/judge/etc/judge.conf | grep OJ_RUNNING`
 sed -i "s/${cdbusername}/OJ_USER_NAME=${DB_USERNAME}/g" /home/judge/etc/judge.conf
 sed -i "s/${cdbpassword}/OJ_PASSWORD=${DB_PASSWORD}/g"  /home/judge/etc/judge.conf
 sed -i "s/${ccpu}/OJ_RUNNING=${CPU}/g"                  /home/judge/etc/judge.conf

--- a/trunk/install/restore.centos7.sh
+++ b/trunk/install/restore.centos7.sh
@@ -62,8 +62,8 @@ sed -i "s/${ccpu}/OJ_RUNNING=${CPU}/g"                  /home/judge/etc/judge.co
 echo "adjustment web config file"
 cdbuser=`cat /home/judge/src/web/include/db_info.inc.php | grep static |grep DB_USER`
 cdbpass=`cat /home/judge/src/web/include/db_info.inc.php | grep static |grep DB_PASS`
-sed -i "s/${cdbuser}/static\ \ \$DB_USER=\"${DB_USERNAME}\"/g" /home/judge/src/web/include/db_info.inc.php
-sed -i "s/${cdbpass}/static\ \ \$DB_PASS=\"${DB_PASSWORD}\"/g" /home/judge/src/web/include/db_info.inc.php
+sed -i "s/${cdbuser}/static\ \ \$DB_USER=\"${DB_USERNAME}\";/g" /home/judge/src/web/include/db_info.inc.php
+sed -i "s/${cdbpass}/static\ \ \$DB_PASS=\"${DB_PASSWORD}\";/g" /home/judge/src/web/include/db_info.inc.php
 
 chmod 775 -R /home/judge/data
 chmod 700 /home/judge/etc/judge.conf

--- a/trunk/install/restore.centos7.sh
+++ b/trunk/install/restore.centos7.sh
@@ -7,6 +7,8 @@ else
     archive=`ls -r /home/judge/backup | head -1`;
 fi
 
+echo "restore archive ${archive}"
+
 # Get database password
 OJ_USERNAME=`cat /home/judge/etc/judge.conf | grep OJ_USER_NAME`
 OJ_PASSWORD=`cat /home/judge/etc/judge.conf | grep OJ_PASSWORD`

--- a/trunk/install/restore.centos7.sh
+++ b/trunk/install/restore.centos7.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/bash
+
+# Get backup archive file
+if [ ${#} > 0 ];then
+    archive=${1};
+else
+    archive=`ls -r /home/judge/backup | head -1`;
+fi
+
+# Get database password
+OJ_USERNAME=`cat /home/judge/etc/judge.conf | grep OJ_USER_NAME`
+OJ_PASSWORD=`cat /home/judge/etc/judge.conf | grep OJ_PASSWORD`
+DB_USERNAME=`echo ${OJ_USER_NAME:13}`
+DB_PASSWORD=`echo ${OJ_PASSWORD:12}`
+
+if [ -e /home/judge/src/install/backup.centos7.sh ];then
+    echo "backup current archive for restoring when interrupted"
+    bash /home/judge/src/install/backup.centos7.sh
+else
+    echo "no backup shell cannot create backup archive"
+fi 
+
+# clear old files
+rm -rf /home/judge/data
+rm -rf /home/judge/etc
+rm -rf /home/judge/src/web
+
+# start restore
+tar -xvf ${archive} -C /home/judge/backup/temp
+
+# restore database
+echo "restore database"
+mysql -u${DB_USERNAME} -p${DB_PASSWORD} < /home/judge/backup/temp/jol.sql
+
+# restore data directory
+echo "restore data directory"
+cp -r /home/judge/backup/temp/data /home/judge/data
+
+# restore config files
+echo "restore config files"
+cp -r /home/judge/backup/temp/etc /home/judge/etc
+
+# restore web files
+cp -r /home/judge/backup/temp/src/web /home/judge/src/web
+
+# adjustment config file
+CPU=`cat /proc/cpuinfo| grep "processor"| wc -l`
+cdbusername = `cat /home/judge/etc/judge.conf | grep OJ_USER_NAME`
+cdbpassword = `cat /home/judge/etc/judge.conf | grep OJ_PASSWORD`
+ccpu        = `cat /home/judge/etc/judge.conf | grep OJ_RUNNING`
+sed -i "s/${cdbusername}/OJ_USER_NAME=${DB_USERNAME}/g" /home/judge/etc/judge.conf
+sed -i "s/${cdbpassword}/OJ_PASSWORD=${DB_PASSWORD}/g"  /home/judge/etc/judge.conf
+sed -i "s/${ccpu}/OJ_RUNNING=${CPU}/g"                  /home/judge/etc/judge.conf
+
+chmod 775 -R /home/judge/data
+chmod 700 /home/judge/etc/judge.conf
+chmod 700 /home/judge/src/web/include/db_info.inc.php
+chown -R apache:apache /home/judge/data
+chown apache /home/judge/src/web/include/db_info.inc.php
+chown apache /home/judge/src/web/upload 

--- a/trunk/install/restore.centos7.sh
+++ b/trunk/install/restore.centos7.sh
@@ -12,7 +12,7 @@ echo "restore archive ${archive}"
 # Get database password
 OJ_USERNAME=`cat /home/judge/etc/judge.conf | grep OJ_USER_NAME`
 OJ_PASSWORD=`cat /home/judge/etc/judge.conf | grep OJ_PASSWORD`
-DB_USERNAME=`echo ${OJ_USER_NAME:13}`
+DB_USERNAME=`echo ${OJ_USERNAME:13}`
 DB_PASSWORD=`echo ${OJ_PASSWORD:12}`
 
 if [ -e /home/judge/src/install/backup.centos7.sh ];then

--- a/trunk/install/restore.centos7.sh
+++ b/trunk/install/restore.centos7.sh
@@ -27,6 +27,9 @@ rm -rf /home/judge/data
 rm -rf /home/judge/etc
 rm -rf /home/judge/src/web
 
+# create temp directory
+mkdir /home/judge/backup/temp
+
 # start restore
 tar -xvf /home/judge/backup/${archive} -C /home/judge/backup/temp
 
@@ -60,3 +63,6 @@ chmod 700 /home/judge/src/web/include/db_info.inc.php
 chown -R apache:apache /home/judge/data
 chown apache /home/judge/src/web/include/db_info.inc.php
 chown apache /home/judge/src/web/upload 
+
+# clear temp directory
+rm -rf /home/judge/backup/temp

--- a/trunk/install/restore.centos7.sh
+++ b/trunk/install/restore.centos7.sh
@@ -48,7 +48,8 @@ cp -r /home/judge/backup/temp/etc /home/judge/etc
 # restore web files
 cp -r /home/judge/backup/temp/src/web /home/judge/src/web
 
-# adjustment config file
+# adjustment judge config file
+echo "adjustment judge config file"
 CPU=`cat /proc/cpuinfo| grep "processor"| wc -l`
 cdbusername=`cat /home/judge/etc/judge.conf | grep OJ_USER_NAME`
 cdbpassword=`cat /home/judge/etc/judge.conf | grep OJ_PASSWORD`
@@ -56,6 +57,13 @@ ccpu=`cat /home/judge/etc/judge.conf | grep OJ_RUNNING`
 sed -i "s/${cdbusername}/OJ_USER_NAME=${DB_USERNAME}/g" /home/judge/etc/judge.conf
 sed -i "s/${cdbpassword}/OJ_PASSWORD=${DB_PASSWORD}/g"  /home/judge/etc/judge.conf
 sed -i "s/${ccpu}/OJ_RUNNING=${CPU}/g"                  /home/judge/etc/judge.conf
+
+# adjustment web config file
+echo "adjustment web config file"
+cdbuser=`cat /home/judge/src/web/include/db_info.inc.php | grep static |grep DB_USER`
+cdbpass=`cat /home/judge/src/web/include/db_info.inc.php | grep static |grep DB_PASS`
+sed -i "s/${cdbuser}/static\ \ \$DB_USER=\"${DB_USERNAME}\"/g" /home/judge/src/web/include/db_info.inc.php
+sed -i "s/${cdbpass}/static\ \ \$DB_PASS=\"${DB_PASSWORD}\"/g" /home/judge/src/web/include/db_info.inc.php
 
 chmod 775 -R /home/judge/data
 chmod 700 /home/judge/etc/judge.conf

--- a/trunk/install/restore.centos7.sh
+++ b/trunk/install/restore.centos7.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/bash
 
 # Get backup archive file
-if [ ${#} > 0 ];then
+if [ ${#} -gt 0 ];then
     archive=${1};
 else
     archive=`ls -r /home/judge/backup | head -1`;
@@ -28,7 +28,7 @@ rm -rf /home/judge/etc
 rm -rf /home/judge/src/web
 
 # start restore
-tar -xvf ${archive} -C /home/judge/backup/temp
+tar -xvf /home/judge/backup/${archive} -C /home/judge/backup/temp
 
 # restore database
 echo "restore database"


### PR DESCRIPTION
为Centos7添加了`备份/恢复`脚本，目前未测试Centos7<->Debian/Ubuntu交叉备份
本脚本使用有一系列的断言(asserts)，请自行判断
>>>
 1. 断言`judge/web`使用同一数据库
 2. 断言`使用分布式判题终端`的用户具备修改完善本脚本的能力
>>>