### PR TITLE
Auto installation script

### DIFF
--- a/trunk/install/install+.sh
+++ b/trunk/install/install+.sh
@@ -5,6 +5,8 @@ ubuntu14=`cat /etc/os-release | grep PRETTY_NAME | grep Ubuntu | grep 14`
 ubuntu16=`cat /etc/os-release | grep PRETTY_NAME | grep Ubuntu | grep 16`
 ubuntu18=`cat /etc/os-release | grep PRETTY_NAME | grep Ubuntu | grep 18`
 
+# remind: centos7 doesn't install wget with minimal installation and ubuntu doesn't install curl by default !!!
+
 if [ -n "${centos7}" ];then
     sudo curl https://github.com/zhblue/hustoj/raw/master/trunk/install/install-centos7.sh | sudo bash ;
 elif [ -n "${ubuntu14}" ];then

--- a/trunk/install/install+.sh
+++ b/trunk/install/install+.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/bash
+
+centos7=`cat /etc/os-release | grep PRETTY_NAME | grep CentOS | grep 7 `
+ubuntu14=`cat /etc/os-release | grep PRETTY_NAME | grep Ubuntu | grep 14`
+ubuntu16=`cat /etc/os-release | grep PRETTY_NAME | grep Ubuntu | grep 16`
+ubuntu18=`cat /etc/os-release | grep PRETTY_NAME | grep Ubuntu | grep 18`
+
+if [ -n "${centos7}" ];then
+    own=apache;
+elif [ -n "${ubuntu14}" ];then
+    own=judge;
+elif [ -n "${ubuntu16}" ];then
+    own=www-data;
+elif [ -n "${ubuntu18}" ];then
+    own=www-data;
+fi

--- a/trunk/install/install+.sh
+++ b/trunk/install/install+.sh
@@ -8,14 +8,20 @@ ubuntu18=`cat /etc/os-release | grep PRETTY_NAME | grep Ubuntu | grep 18`
 # remind: centos7 doesn't install wget with minimal installation and ubuntu doesn't install curl by default !!!
 
 if [ -n "${centos7}" ];then
+    echo "CentOS7.* detected" ;
     sudo curl https://github.com/zhblue/hustoj/raw/master/trunk/install/install-centos7.sh | sudo bash ;
 elif [ -n "${ubuntu14}" ];then
+    echo "Ubuntu14.* detected" ;
     sudo apt-get -y install curl ;
     sudo curl https://github.com/zhblue/hustoj/raw/master/trunk/install/install-ubuntu14.04.sh | sudo bash ;
 elif [ -n "${ubuntu16}" ];then
+    echo "Ubuntu16.* detected" ;
     sudo apt-get -y install curl ;
     sudo curl https://github.com/zhblue/hustoj/raw/master/trunk/install/install-ubuntu16+.sh | sudo bash ;
 elif [ -n "${ubuntu18}" ];then
+    echo "Ubuntu18.* detected" ;
     sudo apt-get -y install curl ;
     sudo curl https://github.com/zhblue/hustoj/raw/master/trunk/install/install-ubuntu18.04.sh | sudo bash ;
+else
+    echo "Not support yet system release"
 fi

--- a/trunk/install/install+.sh
+++ b/trunk/install/install+.sh
@@ -6,11 +6,14 @@ ubuntu16=`cat /etc/os-release | grep PRETTY_NAME | grep Ubuntu | grep 16`
 ubuntu18=`cat /etc/os-release | grep PRETTY_NAME | grep Ubuntu | grep 18`
 
 if [ -n "${centos7}" ];then
-    own=apache;
+    sudo curl https://github.com/zhblue/hustoj/raw/master/trunk/install/install-centos7.sh | sudo bash ;
 elif [ -n "${ubuntu14}" ];then
-    own=judge;
+    sudo apt-get -y install curl ;
+    sudo curl https://github.com/zhblue/hustoj/raw/master/trunk/install/install-ubuntu14.04.sh | sudo bash ;
 elif [ -n "${ubuntu16}" ];then
-    own=www-data;
+    sudo apt-get -y install curl ;
+    sudo curl https://github.com/zhblue/hustoj/raw/master/trunk/install/install-ubuntu16+.sh | sudo bash ;
 elif [ -n "${ubuntu18}" ];then
-    own=www-data;
+    sudo apt-get -y install curl ;
+    sudo curl https://github.com/zhblue/hustoj/raw/master/trunk/install/install-ubuntu18.04.sh | sudo bash ;
 fi

--- a/trunk/install/install-centos7.sh
+++ b/trunk/install/install-centos7.sh
@@ -4,11 +4,16 @@ DBUSER="root"
 DBPASS=`tr -cd '[:alnum:]' < /dev/urandom | fold -w30 | head -n1`
 CPU=`cat /proc/cpuinfo| grep "processor"| wc -l`
 
+yum -y update
+
+# avoid minimal installation no wget
+yum -y install wget
+
+# install nginx
 wget http://nginx.org/packages/centos/7/x86_64/RPMS/nginx-1.14.0-1.el7_4.ngx.x86_64.rpm
 rpm -ivh nginx-1.14.0-1.el7_4.ngx.x86_64.rpm
 rm -rf nginx-1.14.0-1.el7_4.ngx.x86_64.rpm
 
-yum -y update
 yum -y install epel-release yum-utils
 yum -y install http://rpms.remirepo.net/enterprise/remi-release-7.rpm
 yum-config-manager --enable remi-php72

--- a/trunk/install/restore+.sh
+++ b/trunk/install/restore+.sh
@@ -79,7 +79,7 @@ elif [ -n "${ubuntu14}" ];then
     own=judge;
 elif [ -n "${ubuntu16}" ];then
     own=www-data;
-elif [ -n $"{ubuntu18}" ];then
+elif [ -n "${ubuntu18}" ];then
     own=www-data;
 fi
 


### PR DESCRIPTION
Installation HUSTOJ with auto-detect linux release
>>>
Current auto-detect support :
- Centos7.*
- Ubuntu14.*
- Ubuntu16.*
- Ubuntu18.*
>>>
After that , I want to support users install HUSTOJ with themselves github-subversion repository, because then they could update them HUSTOJ with svn update immediately both test before create pull request ( I use GITLAB - CI/CD now , but I couldn't test my newest commit )