### PR TITLE
更改名校联赛实现方法 FOR Centos7

### DIFF
--- a/trunk/install/default.conf
+++ b/trunk/install/default.conf
@@ -19,6 +19,10 @@ server {
         include                     fastcgi_params;
     }
 
+    location /recent-contest.json {
+        proxy_pass http://contests.acmicpc.info/contests.json;
+    }
+
     error_page 404 /404.html;
         location = /40x.html {
     }

--- a/trunk/install/default.conf
+++ b/trunk/install/default.conf
@@ -6,16 +6,16 @@ server {
     index       index.php;
     root         /home/judge/src/web;
 
-	location / {
+    location / {
 
-	}
+    }
     
     location ~ \.php$ {
-	    fastcgi_index               index.php;
+        fastcgi_index               index.php;
         fastcgi_pass                127.0.0.1:9000;
         fastcgi_param               SCRIPT_FILENAME $document_root$fastcgi_script_name;
         fastcgi_split_path_info     ^(.+\.php)(/.+)$;
-	    client_max_body_size        80m;
+        client_max_body_size        80m;
         include                     fastcgi_params;
     }
 


### PR DESCRIPTION
更改名校联赛实现方法，采用nginx反向代理+js渲染表格实现（仅限bs3,ie,sweet三个模板）。