### PR TITLE
[FIX] exit mainloop when call for exit and STOP flag set true

### DIFF
--- a/trunk/core/judged/judged.cc
+++ b/trunk/core/judged/judged.cc
@@ -656,11 +656,11 @@ int main(int argc, char** argv) {
 	init_mysql_conf();	// set the database info
 #endif
 	signal(SIGQUIT, call_for_exit);
-	signal(SIGKILL, call_for_exit);
+	signal(SIGINT, call_for_exit);
 	signal(SIGTERM, call_for_exit);
 	int j = 1;
 	int n = 0;
-	while (1) {			// start to run
+	while (!STOP) {			// start to run until call for exit
 		n=0;
 		while (j && (http_judge
 #ifdef _mysql_h


### PR DESCRIPTION
1.修复了judged在接收到TERM/QUIT/INT信号时不会退出的问题
2.KILL信号不可捕获 不应尝试向signal()注册