### PR TITLE
完善CSRF防护

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,3 +1,5 @@
+image: docker:latest
+
 stages:
   - build
 

--- a/trunk/web/include/csrf_check.php
+++ b/trunk/web/include/csrf_check.php
@@ -1,15 +1,14 @@
 <?php
-  @session_start();
-  if( $_SERVER['REQUEST_METHOD']=='POST'  ){
-	if (isset($_SESSION[$OJ_NAME.'_'.'csrf_keys'])
-   		&& is_array($_SESSION[$OJ_NAME.'_'.'csrf_keys'])
-		&& isset($_POST['csrf'])
-   		&& in_array($_POST['csrf'],$_SESSION[$OJ_NAME.'_'.'csrf_keys'])
-   	){
-//		echo "<!-csrf check passed->";
-  	}else{	
-		echo "<!-csrf check failed->";
-		exit(1);
+  	@session_start();
+  	if( $_SERVER['REQUEST_METHOD'] == 'POST'){
+	  	if( !isset($_SESSION[$OJ_NAME.'_'.'csrf_keys'])
+			|| !is_array($_SESSION[$OJ_NAME.'_'.'csrf_keys'])
+	  		|| !isset($_POST['csrf'])
+			|| !in_array($_POST['csrf'], $_SESSION[$OJ_NAME.'_'.'csrf_keys'])
+		){
+		  	http_response_code(403);
+		  	echo "Invalid csrf token";
+		  	exit;
+		}
   	}
-  }
 ?>

--- a/trunk/web/register.php
+++ b/trunk/web/register.php
@@ -2,6 +2,7 @@
 require_once("./include/db_info.inc.php");
 if(isset($OJ_REGISTER)&&!$OJ_REGISTER) exit(0);
 require_once("./include/my_func.inc.php");
+require_once("./include/csrf_check.php");
 $err_str="";
 $err_cnt=0;
 $len;


### PR DESCRIPTION
CSRF校验失败时，使用标准403 Forbidden状态码，可兼容AJAX请求的异常处理