### PR TITLE
Docker拆分完成

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,3 +13,13 @@ build:
   script:
     - docker build --pull -t $CI_REGISTRY_IMAGE .
     - docker push $CI_REGISTRY_IMAGE
+
+build-mysql:
+  stage: build
+  services:
+    - docker:dind
+  before_script:
+    - docker login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASSWORD $CI_REGISTRY
+  script:
+    - docker build --pull --file=docker/mysql/Dockerfile -t $CI_REGISTRY_IMAGE:mysql .
+    - docker push $CI_REGISTRY_IMAGE:mysql

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,3 +33,13 @@ build-mysql:
   script:
     - docker build --pull --file=docker/mysql/Dockerfile -t $CI_REGISTRY_IMAGE:mysql .
     - docker push $CI_REGISTRY_IMAGE:mysql
+
+build-web:
+  stage: build
+  services:
+    - docker:dind
+  before_script:
+    - docker login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASSWORD $CI_REGISTRY
+  script:
+    - docker build --pull --file=docker/judge/Dockerfile -t $CI_REGISTRY_IMAGE:judge .
+    - docker push $CI_REGISTRY_IMAGE:judge

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -34,7 +34,7 @@ build-mysql:
     - docker build --pull --file=docker/mysql/Dockerfile -t $CI_REGISTRY_IMAGE:mysql .
     - docker push $CI_REGISTRY_IMAGE:mysql
 
-build-web:
+build-judge:
   stage: build
   services:
     - docker:dind

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,6 +14,16 @@ build:
     - docker build --pull -t $CI_REGISTRY_IMAGE .
     - docker push $CI_REGISTRY_IMAGE
 
+build-web:
+  stage: build
+  services:
+    - docker:dind
+  before_script:
+    - docker login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASSWORD $CI_REGISTRY
+  script:
+    - docker build --pull --file=docker/web/Dockerfile -t $CI_REGISTRY_IMAGE:web .
+    - docker push $CI_REGISTRY_IMAGE:web
+
 build-mysql:
   stage: build
   services:

--- a/docker/judge/Dockerfile
+++ b/docker/judge/Dockerfile
@@ -1,0 +1,35 @@
+FROM ubuntu:18.04
+
+COPY docker/sources.list /etc/apt/sources.list
+
+# Linux: Aliyun Apt Mirrors.
+RUN apt-get -y update  && \
+    apt-get -y upgrade && \
+    DEBIAN_FRONTEND=noninteractive \
+    apt-get -y install --no-install-recommends \
+        libmysqlclient-dev \
+        libmysql++-dev \
+        make \
+        flex \
+        gcc \
+        g++ \
+        openjdk-11-jdk
+
+COPY trunk /trunk
+
+COPY docker/ /opt/docker/
+
+RUN bash /opt/docker/judge/setup.sh
+
+# sharing data volume with web container
+VOLUME [ "/home/judge/data" ]
+
+ENV HOSTNAME=localhost
+
+ENV DATABASE=jol
+
+ENV USERNAME=root
+
+ENV PASSWORD=root
+
+ENTRYPOINT [ "/bin/bash", "/opt/docker/judge/entrypoint.sh" ]

--- a/docker/judge/entrypoint.sh
+++ b/docker/judge/entrypoint.sh
@@ -1,0 +1,19 @@
+set -xe
+
+CPU=`grep "cpu cores" /proc/cpuinfo |head -1|awk '{print $4}'`
+
+sed -i "s#OJ_HOST_NAME=127.0.0.1#OJ_HOST_NAME=$HOSTNAME#g" /home/judge/etc/judge.conf
+sed -i "s#OJ_USER_NAME=root#OJ_USER_NAME=$USERNAME#g"      /home/judge/etc/judge.conf
+sed -i "s#OJ_PASSWORD=root#OJ_PASSWORD=$PASSWORD#g"        /home/judge/etc/judge.conf
+sed -i "s#OJ_RUNNING=1#OJ_RUNNING=$CPU#g"                  /home/judge/etc/judge.conf
+
+RUNNING=`cat /home/judge/etc/judge.conf | grep OJ_RUNNING`
+RUNNING=${RUNNING:11}
+for i in `seq 1 $RUNNING`; do
+    mkdir -p    /home/judge/run`expr ${i} - 1`;
+    chown judge /home/judge/run`expr ${i} - 1`;
+done 
+
+service hustoj start
+
+while true; do sleep 1; done

--- a/docker/judge/setup.sh
+++ b/docker/judge/setup.sh
@@ -1,0 +1,34 @@
+set -xe
+
+# Hustoj basic file system
+useradd -m -u 1536 judge
+mkdir -p /home/judge/etc
+mkdir -p /home/judge/data
+mv /trunk /home/judge/src
+chmod -R 700 /home/judge/etc
+chown -R www-data:www-data /home/judge/data
+
+# Judge daemon and client
+make      -C /home/judge/src/core/judged
+make      -C /home/judge/src/core/judge_client
+make exes -C /home/judge/src/core/sim/sim_3_01
+cp /home/judge/src/core/judged/judged                /usr/bin/judged
+cp /home/judge/src/core/judge_client/judge_client    /usr/bin/judge_client 
+cp /home/judge/src/core/sim/sim_3_01/sim_c.exe       /usr/bin/sim_c
+cp /home/judge/src/core/sim/sim_3_01/sim_c++.exe     /usr/bin/sim_cc
+cp /home/judge/src/core/sim/sim_3_01/sim_java.exe    /usr/bin/sim_java
+cp /home/judge/src/core/sim/sim.sh                   /usr/bin/sim.sh
+cp /home/judge/src/install/hustoj                    /etc/init.d/hustoj
+chmod +x /home/judge/src/install/ans2out
+chmod +x /usr/bin/judged
+chmod +X /usr/bin/judge_client
+chmod +x /usr/bin/sim_c
+chmod +X /usr/bin/sim_cc
+chmod +x /usr/bin/sim_java
+chmod +x /usr/bin/sim.sh
+
+# Adjust system configuration
+cp /home/judge/src/install/java0.policy  /home/judge/etc/
+cp /home/judge/src/install/judge.conf    /home/judge/etc/
+sed -i "s#OJ_COMPILE_CHROOT=1#OJ_COMPILE_CHROOT=0#g"     /home/judge/etc/judge.conf
+sed -i "s#OJ_SHM_RUN=1#OJ_SHM_RUN=0#g"                   /home/judge/etc/judge.conf

--- a/docker/mysql/Dockerfile
+++ b/docker/mysql/Dockerfile
@@ -1,0 +1,3 @@
+FROM mysql:5.7
+
+COPY trunk/install/db.sql /docker-entrypoint-initdb.d/

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -22,7 +22,8 @@ COPY docker/ /opt/docker/
 
 RUN bash /opt/docker/web/setup.sh
 
-VOLUME [ "/home/judge/src/web" ]
+# sharing data volume with judge container
+VOLUME [ "/home/judge/data" ]
 
 ENV HOSTNAME=localhost
 

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -1,0 +1,35 @@
+FROM ubuntu:18.04
+
+COPY docker/sources.list /etc/apt/sources.list
+
+# Linux: Aliyun Apt Mirrors.
+RUN apt-get -y update  && \
+    apt-get -y upgrade && \
+    DEBIAN_FRONTEND=noninteractive \
+    apt-get -y install --no-install-recommends \
+        nginx \
+        php-common \
+        php-fpm \
+        php-mysql \
+        php-gd \
+        php-zip \
+        php-mbstring \
+        php-xml
+
+COPY trunk/ /trunk/
+
+COPY docker/ /opt/docker/
+
+RUN bash /opt/docker/web/setup.sh
+
+VOLUME [ "/home/judge/src/web" ]
+
+ENV HOSTNAME=localhost
+
+ENV DATABASE=jol
+
+ENV USERNAME=root
+
+ENV PASSWORD=root
+
+ENTRYPOINT [ "/bin/bash", "/opt/docker/web/entrypoint.sh" ]

--- a/docker/web/entrypoint.sh
+++ b/docker/web/entrypoint.sh
@@ -1,0 +1,9 @@
+set -xe
+
+sed -i "s#DB_HOST=\"localhost\"#DB_HOST=\"$HOSTNAME\"#g"    /home/judge/src/web/include/db_info.inc.php
+sed -i "s#DB_NAME=\"jol\"#DB_NAME=\"$DATABASE\"#g"          /home/judge/src/web/include/db_info.inc.php
+sed -i "s#DB_USER=\"root\"#DB_USER=\"$USERNAME\"#g"         /home/judge/src/web/include/db_info.inc.php
+sed -i "s#DB_PASS=\"root\"#DB_PASS=\"$PASSWORD\"#g"         /home/judge/src/web/include/db_info.inc.php
+
+service php7.2-fpm start
+nginx -g "daemon off;"

--- a/docker/web/setup.sh
+++ b/docker/web/setup.sh
@@ -1,0 +1,13 @@
+set -xe
+
+# Hustoj basic file system
+useradd -m -u 1536 judge
+mkdir -p /home/judge/data
+mv /trunk/ /home/judge/src/
+chmod -R 700 /home/judge/src/web/include/
+chown -R www-data:www-data /home/judge/data
+chown -R www-data:www-data /home/judge/src/web
+
+# Adjust system configuration
+cp /home/judge/src/install/default.conf  /etc/nginx/sites-available/default
+sed -i "s#127.0.0.1:9000#unix:/var/run/php/php7.2-fpm.sock#g"    /etc/nginx/sites-available/default

--- a/trunk/install/db.sql
+++ b/trunk/install/db.sql
@@ -1,15 +1,15 @@
 set names utf8mb4; 
-create database jol;
+create database if not exists jol ;
 use jol;
 
-CREATE TABLE  `compileinfo` (
+CREATE TABLE IF NOT EXISTS `compileinfo` (
   `solution_id` int(11) NOT NULL DEFAULT 0,
   `error` text,
   PRIMARY KEY (`solution_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4;
 
 
-CREATE TABLE  `contest` (
+CREATE TABLE IF NOT EXISTS `contest` (
   `contest_id` int(11) NOT NULL AUTO_INCREMENT,
   `title` varchar(255) DEFAULT NULL,
   `start_time` datetime DEFAULT NULL,
@@ -33,7 +33,7 @@ CREATE TABLE IF NOT EXISTS `contest_problem` (
   KEY `Index_contest_id` (`contest_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4;
 
-CREATE TABLE `loginlog` (
+CREATE TABLE IF NOT EXISTS `loginlog` (
   `user_id` varchar(48) NOT NULL DEFAULT '',
   `password` varchar(40) DEFAULT NULL,
   `ip` varchar(46) DEFAULT NULL,
@@ -41,7 +41,7 @@ CREATE TABLE `loginlog` (
   KEY `user_log_index` (`user_id`,`time`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4;
 
-CREATE TABLE  `mail` (
+CREATE TABLE IF NOT EXISTS `mail` (
   `mail_id` int(11) NOT NULL AUTO_INCREMENT,
   `to_user` varchar(48) NOT NULL DEFAULT '',
   `from_user` varchar(48) NOT NULL DEFAULT '',
@@ -55,7 +55,7 @@ CREATE TABLE  `mail` (
   KEY `uid` (`to_user`)
 ) ENGINE=MyISAM AUTO_INCREMENT=1013 DEFAULT CHARSET=utf8mb4;
 
-CREATE TABLE  `news` (
+CREATE TABLE IF NOT EXISTS `news` (
   `news_id` int(11) NOT NULL AUTO_INCREMENT,
   `user_id` varchar(48) NOT NULL DEFAULT '',
   `title` varchar(200) NOT NULL DEFAULT '',
@@ -67,13 +67,13 @@ CREATE TABLE  `news` (
 ) ENGINE=MyISAM AUTO_INCREMENT=1004 DEFAULT CHARSET=utf8mb4;
 
 
-CREATE TABLE  `privilege` (
+CREATE TABLE IF NOT EXISTS `privilege` (
   `user_id` char(48) NOT NULL DEFAULT '',
   `rightstr` char(30) NOT NULL DEFAULT '',
   `defunct` char(1) NOT NULL DEFAULT 'N'
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4;
 
-CREATE TABLE  `problem` (
+CREATE TABLE IF NOT EXISTS `problem` (
   `problem_id` int(11) NOT NULL AUTO_INCREMENT,
   `title` varchar(200) NOT NULL DEFAULT '',
   `description` text,
@@ -94,7 +94,7 @@ CREATE TABLE  `problem` (
   PRIMARY KEY (`problem_id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=1000 DEFAULT CHARSET=utf8mb4;
 
-CREATE TABLE  `reply` (
+CREATE TABLE IF NOT EXISTS `reply` (
   `rid` int(11) NOT NULL AUTO_INCREMENT,
   `author_id` varchar(48) NOT NULL,
   `time` datetime NOT NULL DEFAULT '2016-05-13 19:24:00',
@@ -107,7 +107,7 @@ CREATE TABLE  `reply` (
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4;
 
 
-CREATE TABLE  `sim` (
+CREATE TABLE IF NOT EXISTS `sim` (
   `s_id` int(11) NOT NULL,
   `sim_s_id` int(11) DEFAULT NULL,
   `sim` int(11) DEFAULT NULL,
@@ -115,7 +115,7 @@ CREATE TABLE  `sim` (
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4;
 
 
-CREATE TABLE  `solution` (
+CREATE TABLE IF NOT EXISTS `solution` (
   `solution_id` int(11) NOT NULL AUTO_INCREMENT,
   `problem_id` int(11) NOT NULL DEFAULT 0,
   `user_id` char(48) NOT NULL,
@@ -141,14 +141,14 @@ CREATE TABLE  `solution` (
   KEY `cid` (`contest_id`)
 ) ENGINE=MyISAM row_format=fixed AUTO_INCREMENT=1001 DEFAULT CHARSET=utf8mb4;
 
-CREATE TABLE  `source_code` (
+CREATE TABLE IF NOT EXISTS `source_code` (
   `solution_id` int(11) NOT NULL,
   `source` text NOT NULL,
   PRIMARY KEY (`solution_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4;
-create table source_code_user like source_code;
+CREATE TABLE IF NOT EXISTS source_code_user like source_code;
 
-CREATE TABLE  `topic` (
+CREATE TABLE IF NOT EXISTS `topic` (
   `tid` int(11) NOT NULL AUTO_INCREMENT,
   `title` varbinary(60) NOT NULL,
   `status` int(2) NOT NULL DEFAULT '0',
@@ -160,7 +160,7 @@ CREATE TABLE  `topic` (
   KEY `cid` (`cid`,`pid`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4;
 
-CREATE TABLE  `users` (
+CREATE TABLE IF NOT EXISTS `users` (
   `user_id` varchar(48) NOT NULL DEFAULT '',
   `email` varchar(100) DEFAULT NULL,
   `submit` int(11) DEFAULT '0',
@@ -177,7 +177,7 @@ CREATE TABLE  `users` (
   PRIMARY KEY (`user_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4;
 
-CREATE TABLE `online` (
+CREATE TABLE IF NOT EXISTS `online` (
   `hash` varchar(32) collate utf8mb4_unicode_ci NOT NULL,
   `ip` varchar(46) character set utf8mb4 NOT NULL default '',
   `ua` varchar(255) character set utf8mb4 NOT NULL default '',
@@ -189,19 +189,19 @@ CREATE TABLE `online` (
   UNIQUE KEY `hash` (`hash`)
 ) ENGINE=MEMORY DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
-CREATE TABLE  `runtimeinfo` (
+CREATE TABLE IF NOT EXISTS `runtimeinfo` (
   `solution_id` int(11) NOT NULL DEFAULT 0,
   `error` text,
   PRIMARY KEY (`solution_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4;
 
-CREATE TABLE  `custominput` (
+CREATE TABLE IF NOT EXISTS `custominput` (
   `solution_id` int(11) NOT NULL DEFAULT 0,
   `input_text` text,
   PRIMARY KEY (`solution_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4;
 
-CREATE TABLE  `printer` (
+CREATE TABLE IF NOT EXISTS `printer` (
   `printer_id` int(11) NOT NULL AUTO_INCREMENT,
   `user_id` char(48) NOT NULL,
   `in_date` datetime NOT NULL DEFAULT '2018-03-13 19:38:00',
@@ -212,7 +212,7 @@ CREATE TABLE  `printer` (
   PRIMARY KEY (`printer_id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=1 DEFAULT CHARSET=utf8mb4;
 
-CREATE TABLE  `balloon` (
+CREATE TABLE IF NOT EXISTS `balloon` (
   `balloon_id` int(11) NOT NULL AUTO_INCREMENT,
   `user_id` char(48) NOT NULL,
   `sid` int(11) NOT NULL ,
@@ -222,7 +222,7 @@ CREATE TABLE  `balloon` (
   PRIMARY KEY (`balloon_id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=1 DEFAULT CHARSET=utf8mb4;
 
-CREATE TABLE `share_code` (
+CREATE TABLE IF NOT EXISTS `share_code` (
   `share_id` int(11) NOT NULL AUTO_INCREMENT,
   `user_id` varchar(48) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `share_code` text COLLATE utf8mb4_unicode_ci,

--- a/trunk/install/db.sql
+++ b/trunk/install/db.sql
@@ -247,3 +247,15 @@ begin
  
 end;//
 delimiter ;
+
+DELIMITER //
+CREATE PROCEDURE DEFAULT_ADMINISTRATOR(user_name VARCHAR(48))
+BEGIN
+    DECLARE privileged_count INT DEFAULT 0;
+    SET privileged_count=(SELECT COUNT(1) FROM `privilege`);
+    IF privileged_count=0 THEN
+        INSERT INTO `privilege` values(user_name,'administrator','N');
+    end if;
+end //
+
+CALL DEFAULT_ADMINISTRATOR('admin');


### PR DESCRIPTION
Docker目前拆分成3个模块

- Web
- MySQL
- Judge

Web提供基本的HTTP服务，通过暴露/home/judge/data目录来为判题端提供数据
MySQL通过tcp端口提供服务，可以在其他数据库实例通过db.sql手动创建数据库
Judge通过连接MySQL与挂载Web所暴露的/home/judge/data实现与本地判题相同的逻辑
同时保留原有的all in one容器，用作startup