### PR TITLE
Using auto test ubuntu release script when build Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 FROM ubuntu:18.04
 
-COPY docker/sources.list /etc/apt/sources.list
+COPY trunk/install/sources.list.sh /opt/sources.list.sh
 
 # Linux: Aliyun Apt Mirrors.
-RUN apt-get -y update  && \
+RUN bash /opt/sources.list.sh && \
+    apt-get -y update  && \
     apt-get -y upgrade && \
     DEBIAN_FRONTEND=noninteractive \
     apt-get -y install --no-install-recommends \

--- a/docker/judge/Dockerfile
+++ b/docker/judge/Dockerfile
@@ -1,9 +1,10 @@
 FROM ubuntu:18.04
 
-COPY docker/sources.list /etc/apt/sources.list
+COPY trunk/install/sources.list.sh /opt/sources.list.sh
 
 # Linux: Aliyun Apt Mirrors.
-RUN apt-get -y update  && \
+RUN bash /opt/sources.list.sh &&\
+    apt-get -y update  && \
     apt-get -y upgrade && \
     DEBIAN_FRONTEND=noninteractive \
     apt-get -y install --no-install-recommends \

--- a/docker/sources.list
+++ b/docker/sources.list
@@ -1,3 +1,0 @@
-deb [arch=amd64] http://mirrors.aliyun.com/ubuntu bionic main restricted universe multiverse
-deb [arch=amd64] http://mirrors.aliyun.com/ubuntu bionic-security main restricted universe multiverse
-deb [arch=amd64] http://mirrors.aliyun.com/ubuntu bionic-updates main restricted universe multiverse

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -1,9 +1,10 @@
 FROM ubuntu:18.04
 
-COPY docker/sources.list /etc/apt/sources.list
+COPY trunk/install/sources.list.sh /opt/sources.list.sh
 
 # Linux: Aliyun Apt Mirrors.
-RUN apt-get -y update  && \
+RUN bash /opt/sources.list.sh && \
+    apt-get -y update  && \
     apt-get -y upgrade && \
     DEBIAN_FRONTEND=noninteractive \
     apt-get -y install --no-install-recommends \

--- a/trunk/install/sources.list.sh
+++ b/trunk/install/sources.list.sh
@@ -2,6 +2,8 @@
 
 codename=`cat /etc/os-release | grep UBUNTU_CODENAME | awk -F '=' '{print $2}'`
 
+mv /etc/apt/sources.list /etc/apt/sources.list.bak
+
 cat >/etc/apt/sources.list <<EOF
 # See http://help.ubuntu.com/community/UpgradeNotes for how to upgrade to
 # newer versions of the distribution.

--- a/trunk/install/sources.list.sh
+++ b/trunk/install/sources.list.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/bash
+
+codename=`cat /etc/os-release | grep UBUNTU_CODENAME | awk -F '=' '{print $2}'`
+
+cat >/etc/apt/sources.list <<EOF
+# See http://help.ubuntu.com/community/UpgradeNotes for how to upgrade to
+# newer versions of the distribution.
+deb http://mirrors.aliyun.com/ubuntu/ ${codename} main restricted
+# deb-src http://cn.archive.ubuntu.com/ubuntu/ ${codename} main restricted
+
+## Major bug fix updates produced after the final release of the
+## distribution.
+deb http://mirrors.aliyun.com/ubuntu/ ${codename}-updates main restricted
+# deb-src http://cn.archive.ubuntu.com/ubuntu/ ${codename}-updates main restricted
+
+## N.B. software from this repository is ENTIRELY UNSUPPORTED by the Ubuntu
+## team. Also, please note that software in universe WILL NOT receive any
+## review or updates from the Ubuntu security team.
+deb http://mirrors.aliyun.com/ubuntu/ ${codename} universe
+# deb-src http://cn.archive.ubuntu.com/ubuntu/ ${codename} universe
+deb http://mirrors.aliyun.com/ubuntu/ ${codename}-updates universe
+# deb-src http://cn.archive.ubuntu.com/ubuntu/ ${codename}-updates universe
+
+## N.B. software from this repository is ENTIRELY UNSUPPORTED by the Ubuntu 
+## team, and may not be under a free licence. Please satisfy yourself as to 
+## your rights to use the software. Also, please note that software in 
+## multiverse WILL NOT receive any review or updates from the Ubuntu
+## security team.
+deb http://mirrors.aliyun.com/ubuntu/ ${codename} multiverse
+# deb-src http://cn.archive.ubuntu.com/ubuntu/ ${codename} multiverse
+deb http://mirrors.aliyun.com/ubuntu/ ${codename}-updates multiverse
+# deb-src http://cn.archive.ubuntu.com/ubuntu/ ${codename}-updates multiverse
+
+## N.B. software from this repository may not have been tested as
+## extensively as that contained in the main release, although it includes
+## newer versions of some applications which may provide useful features.
+## Also, please note that software in backports WILL NOT receive any review
+## or updates from the Ubuntu security team.
+deb http://mirrors.aliyun.com/ubuntu/ ${codename}-backports main restricted universe multiverse
+# deb-src http://cn.archive.ubuntu.com/ubuntu/ ${codename}-backports main restricted universe multiverse
+
+## Uncomment the following two lines to add software from Canonical's
+## 'partner' repository.
+## This software is not part of Ubuntu, but is offered by Canonical and the
+## respective vendors as a service to Ubuntu users.
+# deb http://archive.canonical.com/ubuntu ${codename} partner
+# deb-src http://archive.canonical.com/ubuntu ${codename} partner
+
+deb http://mirrors.aliyun.com/ubuntu/ ${codename}-security main restricted
+# deb-src http://security.ubuntu.com/ubuntu ${codename}-security main restricted
+deb http://mirrors.aliyun.com/ubuntu/ ${codename}-security universe
+# deb-src http://security.ubuntu.com/ubuntu ${codename}-security universe
+deb http://mirrors.aliyun.com/ubuntu/ ${codename}-security multiverse
+# deb-src http://security.ubuntu.com/ubuntu ${codename}-security multiverse
+
+# This system was installed using small removable media
+# (e.g. netinst, live or single CD). The matching "deb cdrom"
+# entries were disabled at the end of the installation process.
+# For information about how to configure apt package sources,
+# see the sources.list(5) manual.
+EOF


### PR DESCRIPTION
Unlike Baoshuo using sed to replace all enumable BASE_URL, it use `sources.list` template to render with ubuntu release code.
If user changed `sources.list` before install HUSTOJ, unexcepted wrong might be raised, but we cannot get any helpful information about it if user self defined sources.list cannot be made public