### PR TITLE
清洗okcalls64：去重callid，并使用entry point name 替代数字

### DIFF
--- a/trunk/core/judge_client/okcalls64.h
+++ b/trunk/core/judge_client/okcalls64.h
@@ -17,115 +17,129 @@
  * along with HUSTOJ. if not, see <http://www.gnu.org/licenses/>.
  */
 //c & c++
-int LANG_CV[CALL_ARRAY_SIZE] = {0,1,2,3,4,5,8,9,10,11,12,17,20,21,59,63,89,99,158,202,228,231,240,272,273,275,511, SYS_time, SYS_read, SYS_uname, SYS_write, SYS_open,
-		SYS_close, SYS_access, SYS_brk, SYS_munmap, SYS_mprotect,
-		SYS_mmap, SYS_fstat, SYS_set_thread_area, 252, SYS_arch_prctl, 0 };
+int LANG_CV[CALL_ARRAY_SIZE] = {
+        SYS_read, SYS_write, SYS_mprotect, SYS_munmap, SYS_brk, SYS_arch_prctl, SYS_pread64, SYS_open, SYS_writev,
+        SYS_time, SYS_futex, SYS_set_thread_area, SYS_access, SYS_clock_gettime, SYS_exit_group, SYS_mq_open,
+        SYS_ioprio_get, SYS_unshare, SYS_set_robust_list, SYS_splice, SYS_close, SYS_stat, SYS_fstat, SYS_execve,
+        SYS_uname, SYS_lseek, SYS_readlink, SYS_mmap, SYS_sysinfo, 0 };
 //pascal
-int LANG_PV[CALL_ARRAY_SIZE] = {0,1,2,3,4,9,10,11,13,16,17,59,89,97,201,231,511,SYS_open, SYS_set_thread_area, SYS_brk, SYS_read,
-		SYS_uname, SYS_write, SYS_execve, SYS_ioctl, SYS_readlink, SYS_mmap,
-		SYS_rt_sigaction, SYS_getrlimit, 252, 191, 158, 231, SYS_close,
-		SYS_exit_group, SYS_munmap, SYS_time, 4, 0 };
+int LANG_PV[CALL_ARRAY_SIZE] = {
+        SYS_read, SYS_write, SYS_mprotect, SYS_munmap, SYS_brk, SYS_rt_sigaction, SYS_arch_prctl, SYS_ioctl,
+        SYS_pread64, SYS_getxattr, SYS_open, SYS_time, SYS_set_thread_area, SYS_exit_group, SYS_ioprio_get, SYS_close,
+        SYS_stat, SYS_execve, SYS_uname, SYS_readlink, SYS_mmap, SYS_getrlimit, 0 };
 //java
-int LANG_JV[CALL_ARRAY_SIZE] = { 0,39,157,257,302,2,3,4,5,9,10,11,12,13,14,17,21,56,59,89,97,104,158,202,218,231,273,257, 
-		61, 22, 6, 33, 8, 13, 16, 111, 110, 39, 79, SYS_fcntl,
-		SYS_getdents64, SYS_getrlimit, SYS_rt_sigprocmask, SYS_futex, SYS_read,
-		SYS_mmap, SYS_stat, SYS_open, SYS_close, SYS_execve, SYS_access,
-		SYS_brk, SYS_readlink, SYS_munmap, SYS_close, SYS_uname, SYS_clone,
-		SYS_uname, SYS_mprotect, SYS_rt_sigaction, SYS_getrlimit, SYS_fstat,
-		SYS_getuid, SYS_getgid, SYS_geteuid, SYS_getegid, SYS_set_thread_area,
-		SYS_set_tid_address, SYS_set_robust_list, SYS_exit_group, 158, 0 };
+int LANG_JV[CALL_ARRAY_SIZE] = {
+        SYS_read, SYS_mprotect, SYS_getuid, SYS_getgid, SYS_geteuid, SYS_getegid, SYS_munmap, SYS_getppid, SYS_getpgrp,
+        SYS_brk, SYS_rt_sigaction, SYS_rt_sigprocmask, SYS_prctl, SYS_arch_prctl, SYS_ioctl, SYS_pread64, SYS_open,
+        SYS_futex, SYS_set_thread_area, SYS_access, SYS_getdents64, SYS_set_tid_address, SYS_pipe, SYS_exit_group,
+        SYS_openat, SYS_set_robust_list, SYS_close, SYS_prlimit64, SYS_dup2, SYS_getpid, SYS_stat, SYS_fstat, SYS_clone,
+        SYS_execve, SYS_lstat, SYS_wait4, SYS_uname, SYS_fcntl, SYS_getcwd, SYS_lseek, SYS_readlink, SYS_mmap,
+        SYS_getrlimit, 0 };
 //ruby
-int LANG_RV[CALL_ARRAY_SIZE] = { 0,1,2,3,4,5,9,10,12,13,14,16,17,21,22,56,59,72,97,98,107,108,131,158,202,218,231,273
-		,96, 340, 4, 126, SYS_access, SYS_arch_prctl, SYS_brk,
-		SYS_close, SYS_execve, SYS_exit_group, SYS_fstat, SYS_futex,
-		SYS_getegid, SYS_geteuid, SYS_getgid, SYS_getuid, SYS_getrlimit,
-		SYS_mmap, SYS_mprotect, SYS_munmap, SYS_open, SYS_read,
-		SYS_rt_sigaction, SYS_rt_sigprocmask, SYS_set_robust_list,
-		SYS_set_tid_address, SYS_write, 0 };
+int LANG_RV[CALL_ARRAY_SIZE] = {
+        SYS_read, SYS_write, SYS_mprotect, SYS_getuid, SYS_getgid, SYS_geteuid, SYS_getegid, SYS_munmap, SYS_brk,
+        SYS_capset, SYS_rt_sigaction, SYS_sigaltstack, SYS_rt_sigprocmask, SYS_arch_prctl, SYS_ioctl, SYS_pread64,
+        SYS_open, SYS_futex, SYS_access, SYS_set_tid_address, SYS_pipe, SYS_exit_group, SYS_set_robust_list, SYS_close,
+        SYS_stat, SYS_fstat, SYS_clone, SYS_execve, SYS_fcntl, SYS_mmap, SYS_gettimeofday, SYS_getrlimit,
+        SYS_getrusage, 0 };
 //bash
-int LANG_BV[CALL_ARRAY_SIZE] = { 0,1,3,4,5,8,9,10,12,13,14,16,17,21,33,39,59,63,72,79,99,102,104,107,108,110,111,158,231,257,302,1,2,3,4,5,8,9,10,12,13,14,16,21,33,39,59,63,72,79,97,99,102,104,107,108,110,111,158,231,
-		96, 22, 61, 56, 42, 41, 79, 158, 117, 60, 39, 102, 191,
-		183,230, SYS_access, SYS_arch_prctl, SYS_brk, SYS_close, SYS_dup2,
-		SYS_execve, SYS_exit_group, SYS_fcntl, SYS_fstat, SYS_getegid,
-		SYS_geteuid, SYS_getgid, SYS_getpgrp, SYS_getpid, SYS_getppid,
-		SYS_getrlimit, SYS_getuid, SYS_ioctl, SYS_lseek, SYS_mmap, SYS_mprotect,
-		SYS_munmap, SYS_open, SYS_read, SYS_rt_sigaction, SYS_rt_sigprocmask,
-		SYS_stat, SYS_uname, SYS_write, 14, 0 };
+int LANG_BV[CALL_ARRAY_SIZE] = {
+        SYS_read, SYS_write, SYS_mprotect, SYS_getuid, SYS_getgid, SYS_geteuid, SYS_getegid, SYS_munmap, SYS_getppid,
+        SYS_getpgrp, SYS_brk, SYS_rt_sigaction, SYS_rt_sigprocmask, SYS_arch_prctl, SYS_ioctl, SYS_pread64,
+        SYS_afs_syscall, SYS_getxattr, SYS_open, SYS_access, SYS_pipe, SYS_clock_nanosleep, SYS_exit_group, SYS_openat,
+        SYS_close, SYS_prlimit64, SYS_dup2, SYS_getpid, SYS_stat, SYS_socket, SYS_connect, SYS_fstat, SYS_clone,
+        SYS_execve, SYS_exit, SYS_wait4, SYS_uname, SYS_fcntl, SYS_getcwd, SYS_lseek, SYS_mmap, SYS_gettimeofday,
+        SYS_getrlimit, SYS_sysinfo, 0 };
 //python
-int LANG_YV[CALL_ARRAY_SIZE] = {0,2,3,4,5,6,8,9,10,11,12,13,14,16,17,21,32,59,72,78,79,89,97,99,102,104,107,108,131,158,217,218,228,231,272,273,318,39,99,302,99,32,72,131,1,202,257,41, 42, 146, SYS_mremap, 158, 117, 60, 39, 102, 191,
-		SYS_access, SYS_arch_prctl, SYS_brk, SYS_close, SYS_execve,
-		SYS_exit_group, SYS_fcntl, SYS_fstat, SYS_futex, SYS_getcwd,
-		SYS_getdents, SYS_getegid, SYS_geteuid, SYS_getgid, SYS_getrlimit,
-		SYS_getuid, SYS_ioctl, SYS_lseek, SYS_lstat, SYS_mmap, SYS_mprotect,
-		SYS_munmap, SYS_open, SYS_read, SYS_readlink, SYS_rt_sigaction,
-		SYS_rt_sigprocmask, SYS_set_robust_list, SYS_set_tid_address, SYS_stat,
-		SYS_write, 0 };
+int LANG_YV[CALL_ARRAY_SIZE] = {
+        SYS_read, SYS_write, SYS_mprotect, SYS_getgid, SYS_geteuid, SYS_getegid, SYS_munmap, SYS_brk, SYS_rt_sigaction,
+        SYS_sigaltstack, SYS_rt_sigprocmask, SYS_sched_get_priority_max, SYS_arch_prctl, SYS_ioctl, SYS_pread64,
+        SYS_getxattr, SYS_open, SYS_futex, SYS_access, SYS_getdents64, SYS_set_tid_address, SYS_clock_gettime,
+        SYS_exit_group, SYS_mremap, SYS_openat, SYS_unshare, SYS_set_robust_list, SYS_close, SYS_prlimit64,
+        SYS_getrandom, SYS_dup, SYS_getpid, SYS_stat, SYS_socket, SYS_connect, SYS_fstat, SYS_execve, SYS_lstat,
+        SYS_exit, SYS_fcntl, SYS_getdents, SYS_getcwd, SYS_lseek, SYS_readlink, SYS_mmap, SYS_getrlimit,
+        SYS_sysinfo, 0 };
 //php
-int LANG_PHV[CALL_ARRAY_SIZE] = { 0,1,2,3,4,5,6,8,9,10,11,12,13,14,16,17,21,59,79,97,158,202,218,231,257,273,
-		257, 20, 146, 78, 158, 117, 60, 39, 102, 191, SYS_access,
-		SYS_brk, SYS_clone, SYS_close, SYS_execve, SYS_exit_group, SYS_fcntl,
-		SYS_fstat, SYS_futex, SYS_getcwd, SYS_getdents64, SYS_getrlimit,
-		SYS_gettimeofday, SYS_ioctl, SYS_lseek, SYS_lstat, SYS_mmap,
-		SYS_mprotect, SYS_munmap, SYS_open, SYS_read, SYS_readlink,
-		SYS_rt_sigaction, SYS_rt_sigprocmask, SYS_set_robust_list,
-		SYS_set_thread_area, SYS_set_tid_address, SYS_stat, SYS_time, SYS_uname,
-		SYS_write, 0 };
+int LANG_PHV[CALL_ARRAY_SIZE] = {
+        SYS_read, SYS_write, SYS_mprotect, SYS_munmap, SYS_brk, SYS_rt_sigaction, SYS_rt_sigprocmask,
+        SYS_sched_get_priority_max, SYS_arch_prctl, SYS_ioctl, SYS_pread64, SYS_getxattr, SYS_open, SYS_writev,
+        SYS_time, SYS_futex, SYS_set_thread_area, SYS_access, SYS_getdents64, SYS_set_tid_address, SYS_exit_group,
+        SYS_openat, SYS_set_robust_list, SYS_close, SYS_getpid, SYS_stat, SYS_fstat, SYS_clone, SYS_execve, SYS_lstat,
+        SYS_exit, SYS_uname, SYS_fcntl, SYS_getdents, SYS_getcwd, SYS_lseek, SYS_readlink, SYS_mmap, SYS_gettimeofday,
+        SYS_getrlimit, 0 };
 //perl
-int LANG_PLV[CALL_ARRAY_SIZE] = {0,1,2,3,4,5,8,9,10,12,13,14,16,17,21,59,72,89,97,102,104,107,108,158,202,218,231,273,
-		 96, 78, 158, 117, 60, 39, 102, 191, SYS_access, SYS_brk,
-		SYS_close, SYS_execve, SYS_exit_group, SYS_fcntl, SYS_fstat, SYS_futex,
-		SYS_getegid, SYS_geteuid, SYS_getgid, SYS_getrlimit, SYS_getuid,
-		SYS_ioctl, SYS_lseek, SYS_mmap, SYS_mprotect, SYS_munmap, SYS_open,
-		SYS_read, SYS_readlink, SYS_rt_sigaction, SYS_rt_sigprocmask,
-		SYS_set_robust_list, SYS_set_thread_area, SYS_set_tid_address, SYS_stat,
-		SYS_time, SYS_uname, SYS_write, 0 };
+int LANG_PLV[CALL_ARRAY_SIZE] = {
+        SYS_read, SYS_write, SYS_mprotect, SYS_getuid, SYS_getgid, SYS_geteuid, SYS_getegid, SYS_munmap, SYS_brk,
+        SYS_rt_sigaction, SYS_rt_sigprocmask, SYS_arch_prctl, SYS_ioctl, SYS_pread64, SYS_getxattr, SYS_open, SYS_time,
+        SYS_futex, SYS_set_thread_area, SYS_access, SYS_set_tid_address, SYS_exit_group, SYS_set_robust_list, SYS_close,
+        SYS_getpid, SYS_stat, SYS_fstat, SYS_execve, SYS_exit, SYS_uname, SYS_fcntl, SYS_getdents, SYS_lseek,
+        SYS_readlink, SYS_mmap, SYS_gettimeofday, SYS_getrlimit, 0 };
 //c-sharp
-int LANG_CSV[CALL_ARRAY_SIZE] = {0,39,157,302,1,2,3,4,5,8,9,10,11,12,13,14,16,17,21,24,41,42,56,59,63,72,78,79,89,97
-		,102,131,137,158,202,204,217,218,229,231,234,257,273, 257, 141, 95, 64, 65, 66
-		, 83, 24, 42, 41, 158, 117, 60,
-		39, 102, 191, SYS_access, SYS_brk, SYS_chmod, SYS_clock_getres,
-		SYS_clock_gettime, SYS_clone, SYS_close, SYS_execve, SYS_exit_group,
-		SYS_fcntl, SYS_fstat, SYS_ftruncate, SYS_futex, SYS_getcwd,
-		SYS_getdents, SYS_geteuid, SYS_getpid, SYS_getppid, SYS_getrlimit,
-		SYS_gettimeofday, SYS_getuid, SYS_ioctl, SYS_lseek, SYS_lstat, SYS_mmap,
-		SYS_mprotect, SYS_mremap, SYS_munmap, SYS_open, SYS_read, SYS_readlink,
-		SYS_rt_sigaction, SYS_rt_sigprocmask, SYS_sched_getaffinity,
-		SYS_sched_getparam, SYS_sched_get_priority_max,
-		SYS_sched_get_priority_min, SYS_sched_getscheduler, SYS_set_robust_list,
-		SYS_set_thread_area, SYS_set_tid_address, SYS_sigaltstack, SYS_stat,
-		SYS_statfs, SYS_tgkill, SYS_time, SYS_uname, SYS_unlink, SYS_write, 0 };
+int LANG_CSV[CALL_ARRAY_SIZE] = {
+        SYS_read, SYS_write, SYS_mprotect, SYS_getuid, SYS_geteuid, SYS_munmap, SYS_getppid, SYS_brk, SYS_rt_sigaction,
+        SYS_sigaltstack, SYS_statfs, SYS_rt_sigprocmask, SYS_setpriority, SYS_sched_getparam, SYS_sched_getscheduler,
+        SYS_sched_get_priority_max, SYS_sched_get_priority_min, SYS_prctl, SYS_arch_prctl, SYS_ioctl, SYS_pread64,
+        SYS_getxattr, SYS_open, SYS_time, SYS_futex, SYS_sched_getaffinity, SYS_set_thread_area, SYS_access,
+        SYS_getdents64, SYS_set_tid_address, SYS_clock_gettime, SYS_clock_getres, SYS_exit_group, SYS_tgkill,
+        SYS_sched_yield, SYS_mremap, SYS_openat, SYS_set_robust_list, SYS_close, SYS_prlimit64, SYS_getpid, SYS_stat,
+        SYS_socket, SYS_connect, SYS_fstat, SYS_clone, SYS_execve, SYS_lstat, SYS_exit, SYS_uname, SYS_semget,
+        SYS_semop, SYS_semctl, SYS_fcntl, SYS_ftruncate, SYS_getdents, SYS_getcwd, SYS_lseek, SYS_mkdir, SYS_unlink,
+        SYS_readlink, SYS_mmap, SYS_chmod, SYS_umask, SYS_gettimeofday, SYS_getrlimit, 0 };
 //objective-c
-int LANG_OV[CALL_ARRAY_SIZE] = { 0,1,2,3,4,5,9,10,12,17,21,59,158,231, 102, 191, SYS_access, SYS_brk, SYS_close,
-		SYS_execve, SYS_exit_group, SYS_fstat, SYS_futex, SYS_getcwd,
-		SYS_getrlimit, SYS_gettimeofday, SYS_mmap, SYS_mprotect, SYS_munmap,
-		SYS_open, SYS_read, SYS_readlink, SYS_rt_sigaction, SYS_rt_sigprocmask,
-		SYS_set_robust_list, SYS_set_thread_area, SYS_set_tid_address,
-		SYS_uname, SYS_write, 0 };
+int LANG_OV[CALL_ARRAY_SIZE] = {
+        SYS_read, SYS_write, SYS_mprotect, SYS_getuid, SYS_munmap, SYS_brk, SYS_rt_sigaction, SYS_rt_sigprocmask,
+        SYS_arch_prctl, SYS_pread64, SYS_getxattr, SYS_open, SYS_futex, SYS_set_thread_area, SYS_access,
+        SYS_set_tid_address, SYS_exit_group, SYS_set_robust_list, SYS_close, SYS_stat, SYS_fstat, SYS_execve, SYS_uname,
+        SYS_getcwd, SYS_readlink, SYS_mmap, SYS_gettimeofday, SYS_getrlimit, 0 };
 //freebasic
-int LANG_BASICV[CALL_ARRAY_SIZE] = { 0,1,2,3,4,5,9,10,12,13,14,16,17,21,59,97,158,173,202,218,231,273,
-		101, 54, 122, 175, 174, 240, 311, 258, 243, 6, 197,
-		252, 146, 195, 192, 33, 45, 125, 191, SYS_access, SYS_brk, SYS_close,
-		SYS_execve, SYS_exit_group, SYS_fstat, SYS_futex, SYS_getrlimit,
-		SYS_ioctl, SYS_ioperm, SYS_mmap, SYS_open, SYS_read, SYS_rt_sigaction,
-		SYS_rt_sigprocmask, SYS_set_robust_list, SYS_set_thread_area,
-		SYS_set_tid_address, SYS_stat, SYS_uname, SYS_write, 0 };
+int LANG_BASICV[CALL_ARRAY_SIZE] = {
+        SYS_read, SYS_write, SYS_mprotect, SYS_ptrace, SYS_brk, SYS_setfsuid, SYS_capget, SYS_rt_sigaction,
+        SYS_rt_sigprocmask, SYS_sched_get_priority_max, SYS_arch_prctl, SYS_ioctl, SYS_pread64, SYS_ioperm,
+        SYS_create_module, SYS_init_module, SYS_getxattr, SYS_lgetxattr, SYS_llistxattr, SYS_removexattr, SYS_open,
+        SYS_futex, SYS_set_thread_area, SYS_access, SYS_set_tid_address, SYS_exit_group, SYS_mq_open,
+        SYS_mq_timedreceive, SYS_ioprio_get, SYS_mkdirat, SYS_set_robust_list, SYS_close, SYS_process_vm_writev,
+        SYS_dup2, SYS_stat, SYS_recvfrom, SYS_fstat, SYS_setsockopt, SYS_execve, SYS_lstat, SYS_uname, SYS_mmap,
+        SYS_getrlimit, 0 };
 //scheme
-int LANG_SV[CALL_ARRAY_SIZE] = { 1, 23, 100, 61, 22, 6, 33, 8, 13, 16, 111, 110, 39, 79,
-		SYS_fcntl, SYS_getdents64, SYS_getrlimit, SYS_rt_sigprocmask, SYS_futex,
-		SYS_read, SYS_mmap, SYS_stat, SYS_open, SYS_close, SYS_execve,
-		SYS_access, SYS_brk, SYS_readlink, SYS_munmap, SYS_close, SYS_uname,
-		SYS_clone, SYS_uname, SYS_mprotect, SYS_rt_sigaction, SYS_getrlimit,
-		SYS_fstat, SYS_getuid, SYS_getgid, SYS_geteuid, SYS_getegid,
-		SYS_set_thread_area, SYS_set_tid_address, SYS_set_robust_list,
-		SYS_exit_group, 158, 0 };
+int LANG_SV[CALL_ARRAY_SIZE] = {
+        SYS_read, SYS_write, SYS_mprotect, SYS_times, SYS_getuid, SYS_getgid, SYS_geteuid, SYS_getegid, SYS_munmap,
+        SYS_getppid, SYS_getpgrp, SYS_brk, SYS_rt_sigaction, SYS_rt_sigprocmask, SYS_arch_prctl, SYS_ioctl, SYS_open,
+        SYS_futex, SYS_set_thread_area, SYS_access, SYS_getdents64, SYS_set_tid_address, SYS_pipe, SYS_select,
+        SYS_exit_group, SYS_set_robust_list, SYS_close, SYS_dup2, SYS_getpid, SYS_stat, SYS_fstat, SYS_clone,
+        SYS_execve, SYS_lstat, SYS_wait4, SYS_uname, SYS_fcntl, SYS_getcwd, SYS_lseek, SYS_readlink, SYS_mmap,
+        SYS_getrlimit, 0 };
 //lua
-int LANG_LUAV[CALL_ARRAY_SIZE]={0,1,2,3,4,5,9,10,11,12,13,17,21,59,158,231,292,0};
+int LANG_LUAV[CALL_ARRAY_SIZE] = {
+        SYS_read, SYS_write, SYS_mprotect, SYS_munmap, SYS_brk, SYS_rt_sigaction, SYS_arch_prctl, SYS_pread64, SYS_open,
+        SYS_access, SYS_exit_group, SYS_dup3, SYS_close, SYS_stat, SYS_fstat, SYS_execve, SYS_mmap, 0 };
 //nodejs javascript
-int LANG_JSV[CALL_ARRAY_SIZE]={0,1,2,3,4,5,6,7,9,10,11,12,13,14,16,17,20,21,56,59,79,89,96,97,102,104,107,108,158,160,186,202,218,228,229,231,232,233,273,290,291,293,0};
+int LANG_JSV[CALL_ARRAY_SIZE] = {
+        SYS_read, SYS_write, SYS_mprotect, SYS_getuid, SYS_getgid, SYS_geteuid, SYS_getegid, SYS_munmap, SYS_brk,
+        SYS_rt_sigaction, SYS_rt_sigprocmask, SYS_arch_prctl, SYS_ioctl, SYS_setrlimit, SYS_pread64, SYS_gettid,
+        SYS_open, SYS_writev, SYS_futex, SYS_access, SYS_set_tid_address, SYS_clock_gettime, SYS_clock_getres,
+        SYS_exit_group, SYS_epoll_wait, SYS_epoll_ctl, SYS_set_robust_list, SYS_eventfd2, SYS_epoll_create1, SYS_pipe2,
+        SYS_close, SYS_stat, SYS_fstat, SYS_clone, SYS_execve, SYS_lstat, SYS_poll, SYS_getcwd, SYS_readlink, SYS_mmap,
+        SYS_gettimeofday, SYS_getrlimit, 0 };
 //go-lang
-int LANG_GOV[CALL_ARRAY_SIZE]={0,1,9,10,11,13,14,17,24,56,59,72,131,158,186,202,204,228,231,257,267,0};
+int LANG_GOV[CALL_ARRAY_SIZE] = {
+        SYS_read, SYS_write, SYS_mprotect, SYS_munmap, SYS_rt_sigaction, SYS_sigaltstack, SYS_rt_sigprocmask,
+        SYS_arch_prctl, SYS_pread64, SYS_gettid, SYS_futex, SYS_sched_getaffinity, SYS_clock_gettime, SYS_exit_group,
+        SYS_sched_yield, SYS_openat, SYS_readlinkat, SYS_clone, SYS_execve, SYS_fcntl, SYS_mmap, 0 };
 //sqlite3
-int LANG_SQLV[CALL_ARRAY_SIZE]={0,1,2,3,4,5,8,9,10,12,13,14,16,17,21,41,42,59,64,72,74,79,87,97,102,107,158,202,218,231,273,0};
+int LANG_SQLV[CALL_ARRAY_SIZE] = {
+        SYS_read, SYS_write, SYS_mprotect, SYS_getuid, SYS_geteuid, SYS_brk, SYS_rt_sigaction, SYS_rt_sigprocmask,
+        SYS_arch_prctl, SYS_ioctl, SYS_pread64, SYS_open, SYS_futex, SYS_access, SYS_set_tid_address, SYS_exit_group,
+        SYS_set_robust_list, SYS_close, SYS_stat, SYS_socket, SYS_connect, SYS_fstat, SYS_execve, SYS_semget, SYS_fcntl,
+        SYS_fsync, SYS_getcwd, SYS_lseek, SYS_unlink, SYS_mmap, SYS_getrlimit, 0 };
 //fortran
-int LANG_FV[CALL_ARRAY_SIZE]={1,5,10,12,13,17,21,59,63,89,158,231,0};
-int LANG_MV[CALL_ARRAY_SIZE]={0,1,3,4,5,6,7,8,9,10,11,12,13,14,16,17,20,21,39,41,42,45,48,52,56,59,63,72,78,79,89,96,102,158,202,204,218,231,257,273,302,318,0};
+int LANG_FV[CALL_ARRAY_SIZE] = {
+        SYS_read, SYS_write, SYS_mprotect, SYS_brk, SYS_rt_sigaction, SYS_arch_prctl, SYS_pread64, SYS_access,
+        SYS_exit_group, SYS_fstat, SYS_execve, SYS_uname, SYS_readlink, 0 };
+//octave
+int LANG_MV[CALL_ARRAY_SIZE] = {
+        SYS_read, SYS_write, SYS_mprotect, SYS_getuid, SYS_munmap, SYS_brk, SYS_rt_sigaction, SYS_rt_sigprocmask,
+        SYS_arch_prctl, SYS_ioctl, SYS_writev, SYS_futex, SYS_sched_getaffinity, SYS_access, SYS_set_tid_address,
+        SYS_exit_group, SYS_openat, SYS_set_robust_list, SYS_close, SYS_prlimit64, SYS_getrandom, SYS_getpid, SYS_stat,
+        SYS_socket, SYS_connect, SYS_recvfrom, SYS_shutdown, SYS_fstat, SYS_getpeername, SYS_clone, SYS_execve,
+        SYS_lstat, SYS_uname, SYS_poll, SYS_fcntl, SYS_getdents, SYS_getcwd, SYS_lseek, SYS_readlink, SYS_mmap,
+        SYS_gettimeofday, 0 };


### PR DESCRIPTION
数组与entry point的对照表参考<unistd_64.h>
清洗数组使用的Python脚本如下：
```python3
# copy from unistd_64.h
hash_map = {
  '0': 'SYS_read',
  '1': 'SYS_write',
  '2': 'SYS_open',
  '3': 'SYS_close',
  '4': 'SYS_stat',
  '5': 'SYS_fstat',
  '6': 'SYS_lstat',
  '7': 'SYS_poll',
  '8': 'SYS_lseek',
  '9': 'SYS_mmap',
  '10': 'SYS_mprotect',
  '11': 'SYS_munmap',
  '12': 'SYS_brk',
  '13': 'SYS_rt_sigaction',
  '14': 'SYS_rt_sigprocmask',
  '15': 'SYS_rt_sigreturn',
  '16': 'SYS_ioctl',
  '17': 'SYS_pread64',
  '18': 'SYS_pwrite64',
  '19': 'SYS_readv',
  '20': 'SYS_writev',
  '21': 'SYS_access',
  '22': 'SYS_pipe',
  '23': 'SYS_select',
  '24': 'SYS_sched_yield',
  '25': 'SYS_mremap',
  '26': 'SYS_msync',
  '27': 'SYS_mincore',
  '28': 'SYS_madvise',
  '29': 'SYS_shmget',
  '30': 'SYS_shmat',
  '31': 'SYS_shmctl',
  '32': 'SYS_dup',
  '33': 'SYS_dup2',
  '34': 'SYS_pause',
  '35': 'SYS_nanosleep',
  '36': 'SYS_getitimer',
  '37': 'SYS_alarm',
  '38': 'SYS_setitimer',
  '39': 'SYS_getpid',
  '40': 'SYS_sendfile',
  '41': 'SYS_socket',
  '42': 'SYS_connect',
  '43': 'SYS_accept',
  '44': 'SYS_sendto',
  '45': 'SYS_recvfrom',
  '46': 'SYS_sendmsg',
  '47': 'SYS_recvmsg',
  '48': 'SYS_shutdown',
  '49': 'SYS_bind',
  '50': 'SYS_listen',
  '51': 'SYS_getsockname',
  '52': 'SYS_getpeername',
  '53': 'SYS_socketpair',
  '54': 'SYS_setsockopt',
  '55': 'SYS_getsockopt',
  '56': 'SYS_clone',
  '57': 'SYS_fork',
  '58': 'SYS_vfork',
  '59': 'SYS_execve',
  '60': 'SYS_exit',
  '61': 'SYS_wait4',
  '62': 'SYS_kill',
  '63': 'SYS_uname',
  '64': 'SYS_semget',
  '65': 'SYS_semop',
  '66': 'SYS_semctl',
  '67': 'SYS_shmdt',
  '68': 'SYS_msgget',
  '69': 'SYS_msgsnd',
  '70': 'SYS_msgrcv',
  '71': 'SYS_msgctl',
  '72': 'SYS_fcntl',
  '73': 'SYS_flock',
  '74': 'SYS_fsync',
  '75': 'SYS_fdatasync',
  '76': 'SYS_truncate',
  '77': 'SYS_ftruncate',
  '78': 'SYS_getdents',
  '79': 'SYS_getcwd',
  '80': 'SYS_chdir',
  '81': 'SYS_fchdir',
  '82': 'SYS_rename',
  '83': 'SYS_mkdir',
  '84': 'SYS_rmdir',
  '85': 'SYS_creat',
  '86': 'SYS_link',
  '87': 'SYS_unlink',
  '88': 'SYS_symlink',
  '89': 'SYS_readlink',
  '90': 'SYS_chmod',
  '91': 'SYS_fchmod',
  '92': 'SYS_chown',
  '93': 'SYS_fchown',
  '94': 'SYS_lchown',
  '95': 'SYS_umask',
  '96': 'SYS_gettimeofday',
  '97': 'SYS_getrlimit',
  '98': 'SYS_getrusage',
  '99': 'SYS_sysinfo',
  '100': 'SYS_times',
  '101': 'SYS_ptrace',
  '102': 'SYS_getuid',
  '103': 'SYS_syslog',
  '104': 'SYS_getgid',
  '105': 'SYS_setuid',
  '106': 'SYS_setgid',
  '107': 'SYS_geteuid',
  '108': 'SYS_getegid',
  '109': 'SYS_setpgid',
  '110': 'SYS_getppid',
  '111': 'SYS_getpgrp',
  '112': 'SYS_setsid',
  '113': 'SYS_setreuid',
  '114': 'SYS_setregid',
  '115': 'SYS_getgroups',
  '116': 'SYS_setgroups',
  '117': 'SYS_setresuid',
  '118': 'SYS_getresuid',
  '119': 'SYS_setresgid',
  '120': 'SYS_getresgid',
  '121': 'SYS_getpgid',
  '122': 'SYS_setfsuid',
  '123': 'SYS_setfsgid',
  '124': 'SYS_getsid',
  '125': 'SYS_capget',
  '126': 'SYS_capset',
  '127': 'SYS_rt_sigpending',
  '128': 'SYS_rt_sigtimedwait',
  '129': 'SYS_rt_sigqueueinfo',
  '130': 'SYS_rt_sigsuspend',
  '131': 'SYS_sigaltstack',
  '132': 'SYS_utime',
  '133': 'SYS_mknod',
  '134': 'SYS_uselib',
  '135': 'SYS_personality',
  '136': 'SYS_ustat',
  '137': 'SYS_statfs',
  '138': 'SYS_fstatfs',
  '139': 'SYS_sysfs',
  '140': 'SYS_getpriority',
  '141': 'SYS_setpriority',
  '142': 'SYS_sched_setparam',
  '143': 'SYS_sched_getparam',
  '144': 'SYS_sched_setscheduler',
  '145': 'SYS_sched_getscheduler',
  '146': 'SYS_sched_get_priority_max',
  '147': 'SYS_sched_get_priority_min',
  '148': 'SYS_sched_rr_get_interval',
  '149': 'SYS_mlock',
  '150': 'SYS_munlock',
  '151': 'SYS_mlockall',
  '152': 'SYS_munlockall',
  '153': 'SYS_vhangup',
  '154': 'SYS_modify_ldt',
  '155': 'SYS_pivot_root',
  '156': 'SYS__sysctl',
  '157': 'SYS_prctl',
  '158': 'SYS_arch_prctl',
  '159': 'SYS_adjtimex',
  '160': 'SYS_setrlimit',
  '161': 'SYS_chroot',
  '162': 'SYS_sync',
  '163': 'SYS_acct',
  '164': 'SYS_settimeofday',
  '165': 'SYS_mount',
  '166': 'SYS_umount2',
  '167': 'SYS_swapon',
  '168': 'SYS_swapoff',
  '169': 'SYS_reboot',
  '170': 'SYS_sethostname',
  '171': 'SYS_setdomainname',
  '172': 'SYS_iopl',
  '173': 'SYS_ioperm',
  '174': 'SYS_create_module',
  '175': 'SYS_init_module',
  '176': 'SYS_delete_module',
  '177': 'SYS_get_kernel_syms',
  '178': 'SYS_query_module',
  '179': 'SYS_quotactl',
  '180': 'SYS_nfsservctl',
  '181': 'SYS_getpmsg',
  '182': 'SYS_putpmsg',
  '183': 'SYS_afs_syscall',
  '184': 'SYS_tuxcall',
  '185': 'SYS_security',
  '186': 'SYS_gettid',
  '187': 'SYS_readahead',
  '188': 'SYS_setxattr',
  '189': 'SYS_lsetxattr',
  '190': 'SYS_fsetxattr',
  '191': 'SYS_getxattr',
  '192': 'SYS_lgetxattr',
  '193': 'SYS_fgetxattr',
  '194': 'SYS_listxattr',
  '195': 'SYS_llistxattr',
  '196': 'SYS_flistxattr',
  '197': 'SYS_removexattr',
  '198': 'SYS_lremovexattr',
  '199': 'SYS_fremovexattr',
  '200': 'SYS_tkill',
  '201': 'SYS_time',
  '202': 'SYS_futex',
  '203': 'SYS_sched_setaffinity',
  '204': 'SYS_sched_getaffinity',
  '205': 'SYS_set_thread_area',
  '206': 'SYS_io_setup',
  '207': 'SYS_io_destroy',
  '208': 'SYS_io_getevents',
  '209': 'SYS_io_submit',
  '210': 'SYS_io_cancel',
  '211': 'SYS_get_thread_area',
  '212': 'SYS_lookup_dcookie',
  '213': 'SYS_epoll_create',
  '214': 'SYS_epoll_ctl_old',
  '215': 'SYS_epoll_wait_old',
  '216': 'SYS_remap_file_pages',
  '217': 'SYS_getdents64',
  '218': 'SYS_set_tid_address',
  '219': 'SYS_restart_syscall',
  '220': 'SYS_semtimedop',
  '221': 'SYS_fadvise64',
  '222': 'SYS_timer_create',
  '223': 'SYS_timer_settime',
  '224': 'SYS_timer_gettime',
  '225': 'SYS_timer_getoverrun',
  '226': 'SYS_timer_delete',
  '227': 'SYS_clock_settime',
  '228': 'SYS_clock_gettime',
  '229': 'SYS_clock_getres',
  '230': 'SYS_clock_nanosleep',
  '231': 'SYS_exit_group',
  '232': 'SYS_epoll_wait',
  '233': 'SYS_epoll_ctl',
  '234': 'SYS_tgkill',
  '235': 'SYS_utimes',
  '236': 'SYS_vserver',
  '237': 'SYS_mbind',
  '238': 'SYS_set_mempolicy',
  '239': 'SYS_get_mempolicy',
  '240': 'SYS_mq_open',
  '241': 'SYS_mq_unlink',
  '242': 'SYS_mq_timedsend',
  '243': 'SYS_mq_timedreceive',
  '244': 'SYS_mq_notify',
  '245': 'SYS_mq_getsetattr',
  '246': 'SYS_kexec_load',
  '247': 'SYS_waitid',
  '248': 'SYS_add_key',
  '249': 'SYS_request_key',
  '250': 'SYS_keyctl',
  '251': 'SYS_ioprio_set',
  '252': 'SYS_ioprio_get',
  '253': 'SYS_inotify_init',
  '254': 'SYS_inotify_add_watch',
  '255': 'SYS_inotify_rm_watch',
  '256': 'SYS_migrate_pages',
  '257': 'SYS_openat',
  '258': 'SYS_mkdirat',
  '259': 'SYS_mknodat',
  '260': 'SYS_fchownat',
  '261': 'SYS_futimesat',
  '262': 'SYS_newfstatat',
  '263': 'SYS_unlinkat',
  '264': 'SYS_renameat',
  '265': 'SYS_linkat',
  '266': 'SYS_symlinkat',
  '267': 'SYS_readlinkat',
  '268': 'SYS_fchmodat',
  '269': 'SYS_faccessat',
  '270': 'SYS_pselect6',
  '271': 'SYS_ppoll',
  '272': 'SYS_unshare',
  '273': 'SYS_set_robust_list',
  '274': 'SYS_get_robust_list',
  '275': 'SYS_splice',
  '276': 'SYS_tee',
  '277': 'SYS_sync_file_range',
  '278': 'SYS_vmsplice',
  '279': 'SYS_move_pages',
  '280': 'SYS_utimensat',
  '281': 'SYS_epoll_pwait',
  '282': 'SYS_signalfd',
  '283': 'SYS_timerfd_create',
  '284': 'SYS_eventfd',
  '285': 'SYS_fallocate',
  '286': 'SYS_timerfd_settime',
  '287': 'SYS_timerfd_gettime',
  '288': 'SYS_accept4',
  '289': 'SYS_signalfd4',
  '290': 'SYS_eventfd2',
  '291': 'SYS_epoll_create1',
  '292': 'SYS_dup3',
  '293': 'SYS_pipe2',
  '294': 'SYS_inotify_init1',
  '295': 'SYS_preadv',
  '296': 'SYS_pwritev',
  '297': 'SYS_rt_tgsigqueueinfo',
  '298': 'SYS_perf_event_open',
  '299': 'SYS_recvmmsg',
  '300': 'SYS_fanotify_init',
  '301': 'SYS_fanotify_mark',
  '302': 'SYS_prlimit64',
  '303': 'SYS_name_to_handle_at',
  '304': 'SYS_open_by_handle_at',
  '305': 'SYS_clock_adjtime',
  '306': 'SYS_syncfs',
  '307': 'SYS_sendmmsg',
  '308': 'SYS_setns',
  '309': 'SYS_getcpu',
  '310': 'SYS_process_vm_readv',
  '311': 'SYS_process_vm_writev',
  '312': 'SYS_kcmp',
  '313': 'SYS_finit_module',
  '314': 'SYS_sched_setattr',
  '315': 'SYS_sched_getattr',
  '316': 'SYS_renameat2',
  '317': 'SYS_seccomp',
  '318': 'SYS_getrandom',
  '319': 'SYS_memfd_create',
  '320': 'SYS_kexec_file_load',
  '321': 'SYS_bpf',
  '322': 'SYS_execveat',
  '323': 'SYS_userfaultfd',
  '324': 'SYS_membarrier',
  '325': 'SYS_mlock2',
  '326': 'SYS_copy_file_range',
  '327': 'SYS_preadv2',
  '328': 'SYS_pwritev2',
  '329': 'SYS_pkey_mprotect',
  '330': 'SYS_pkey_alloc',
  '331': 'SYS_pkey_free',
  '332': 'SYS_statx',
}

hash_map2  = {v: k for k, v in hash_map.items()}

data = """
 0,1,2,3,4,5,8,9,11,12,20,21,59,63,89,99,158,231,240,272,273,275,511, SYS_time, SYS_read, SYS_uname, SYS_write, SYS_open,
    SYS_close, SYS_access, SYS_brk, SYS_munmap, SYS_mprotect,
    SYS_mmap, SYS_fstat, SYS_set_thread_area, 252, SYS_arch_prctl, 0

"""

data = [i.strip() for i in data.split(',')]

for k, v in enumerate(data):
  try:
    v = int(v)
    data[k] = hash_map[str(v)]
  except ValueError:
    pass
  except KeyError:
    print("Error call id in list: %s\n" % str(v))
    data[k] = data[0]

for k, v in enumerate(data):
  data[k] = hash_map2[v]

len1 = len(data)
data = list(set(data))

print("%d duplicate data found.\n" % (len1 - len(data)))

data.sort()

for k in data:
  print(hash_map[k] + ', ', end='')

print(0)

```