### PR TITLE
python judge error fix at AWS EC2 ubuntu20.04

### DIFF
--- a/trunk/core/judge_client/okcalls64.h
+++ b/trunk/core/judge_client/okcalls64.h
@@ -53,7 +53,7 @@ int LANG_BV[CALL_ARRAY_SIZE] = {
 //python
 int LANG_YV[CALL_ARRAY_SIZE] = {
         0,39,186,	
-	318,17,41,42,72,99,217,302,1,2,3,4,5,6,8,9,10,11,12,13,14,16,21,32,59,72,78,79,89,97,102,104,107,108,131,137,158,202,218,231,257,273,
+	318,17,41,42,72,99,217,302,1,2,3,4,5,6,8,9,10,11,12,13,14,16,21,32,59,72,78,79,89,97,102,104,107,108,131,137,158,202,218,228,231,257,273,
         SYS_read, SYS_write, SYS_mprotect, SYS_getuid, SYS_getgid, SYS_geteuid, SYS_getegid, SYS_munmap, SYS_brk,
         SYS_rt_sigaction, SYS_sigaltstack, SYS_rt_sigprocmask, SYS_sched_get_priority_max, SYS_arch_prctl, SYS_ioctl,
         SYS_pread64, SYS_getxattr, SYS_open, SYS_futex, SYS_access, SYS_getdents64, SYS_set_tid_address, SYS_clock_gettime,


### PR DESCRIPTION
python judge error fix

for

Amazon EC2 instance
Ubuntu Server 20.04 LTS (HVM), SSD Volume Type
64bit(x86)