### PR TITLE
fix: 通过率计算错误

### DIFF
--- a/trunk/web/template/mdui/problemset.php
+++ b/trunk/web/template/mdui/problemset.php
@@ -103,7 +103,7 @@
                     echo '<td><a class="mdui-text-color-theme-accent" href="problemset.php?search='.urlencode($row["source"]).'">'.$row["source"].'</td>';
                     echo '<td><a class="mdui-text-color-theme-accent" href="status.php?problem_id='.$row["problem_id"].'&jresult=4">'.$row["accepted"].'</td>';
                     echo '<td><a class="mdui-text-color-theme-accent" href="status.php?problem_id='.$row["problem_id"].'">'.$row["submit"].'</td>';
-                    echo '<td>'.sprintf("%.02lf%%", 100 * $row['accepted'] / ($row['submit'] || 1)).'</td>';
+                    echo '<td>'.sprintf("%.02lf%%", 100 * $row['accepted'] / ($row['submit'] ? $row['submit'] : 1)).'</td>';
                     echo '</tr>';
                 }
                 ?>


### PR DESCRIPTION
首先非常抱歉我的上次pr可能带来了一些误导性的错误 （#744 - 4），在上次提交中为了给 ``` $['submit'] ``` 设置默认值为1使用了 "||" 运算符进行短路运算，但是实际情况是，该运算符在其他语言中是可用的，但是在PHP中可能存在某些问题。从而导致了一个错误：

![image](https://user-images.githubusercontent.com/30247854/107172035-47f8d980-69ff-11eb-83af-d8e52922a044.png)

``` $['submit'] ``` 的值并没有按照预期的值进行设置，而是被直接赋值为1，导致了一个新的错误。这次pr主要是针对这个问题做出的修改。
修改后的显示结果正确：

![image](https://user-images.githubusercontent.com/30247854/107172187-ac1b9d80-69ff-11eb-9139-44c02ca6837e.png)

以下是本地提交的内容：

* fix: 通过率计算错误