### PR TITLE
bs3, Contest problem error fix for admin

### DIFF
--- a/trunk/web/template/bs3/problem.php
+++ b/trunk/web/template/bs3/problem.php
@@ -85,7 +85,7 @@
         	require_once("include/set_get_key.php");
  					echo "<a class='btn btn-success btn-sm' role='button' href=admin/problem_edit.php?id=$id&getkey=".$_SESSION[$OJ_NAME.'_'.'getkey'].">EDIT</a>";
  					echo "<a class='btn btn-success btn-sm' role='button' href=javascript:phpfm(".$row['problem_id'].")>TESTDATA</a>";
-	      			if(count($used_in_contests)>0){
+	      			if($cid==0 && count($used_in_contests)>0){
 					echo "<hr><br>$MSG_PROBLEM_USED_IN:";
 					foreach($used_in_contests as $contests){
 						echo "<a class='label label-warning' href='contest.php?cid=". $contests[0]."'>".$contests[1]." </a><br>";	


### PR DESCRIPTION
At bs3 templateContest problem error fix for admin


for bs3 template

fix
- contest's problem are not viewing ... for admin


<img width="1440" alt="error01" src="https://user-images.githubusercontent.com/92401080/184284009-6bdfa3bb-c7a8-46ec-9432-648a673b30f2.png">

<img width="1440" alt="error02" src="https://user-images.githubusercontent.com/92401080/184284036-8b5ef86c-1191-4f81-bdbc-4eae301b8604.png">








-

fixed

<img width="1440" alt="fixed" src="https://user-images.githubusercontent.com/92401080/184284049-c779b8db-f00d-40d9-ab57-a241acf3dbe0.png">

 