### PR TITLE
修复比赛时提交后无法刷新判题结果的问题

### DIFF
--- a/trunk/web/template/bs3/conteststatus.php
+++ b/trunk/web/template/bs3/conteststatus.php
@@ -347,6 +347,7 @@
 		echo "'$result',";
 	} ?>
   ''];
+  var oj_mark= <?php echo "'$OJ_MARK'";?>;
 </script>
 
 <script src="<?php echo $OJ_CDN_URL?>template/<?php echo $OJ_TEMPLATE?>/auto_refresh.js" ></script>

--- a/trunk/web/template/mdui/conteststatus.php
+++ b/trunk/web/template/mdui/conteststatus.php
@@ -315,6 +315,7 @@
     foreach ($judge_color as $result) {
         echo "'$result',";
     } ?> ''];
+    var oj_mark= <?php echo "'$OJ_MARK'";?>;
     </script>
 
     <script src="template/<?php echo $OJ_TEMPLATE?>/auto_refresh.js"></script>

--- a/trunk/web/template/sidebar/conteststatus.php
+++ b/trunk/web/template/sidebar/conteststatus.php
@@ -147,7 +147,8 @@
                 echo "'$result',";
         } ?>
         ''];
+        var oj_mark= <?php echo "'$OJ_MARK'";?>;
 </script>
-        <script src="template/bs3/auto_refresh.js?v=0.43" ></script>
+        <script src="template/sidebar/auto_refresh.js?v=0.43" ></script>
 
 <?php include("template/$OJ_TEMPLATE/footer.php");?>

--- a/trunk/web/template/sweet/conteststatus.php
+++ b/trunk/web/template/sweet/conteststatus.php
@@ -162,6 +162,7 @@ echo "[<a href=status.php?".$str2."&top=".$bottom."&prevtop=$top>Next Page</a>]"
 		 echo "'$result',";
 		 }
 		?>''];
+		var oj_mark= <?php echo "'$OJ_MARK'";?>;
 	</script>
 	<script src="template/<?php echo $OJ_TEMPLATE?>/auto_refresh.js" ></script>
   </body>

--- a/trunk/web/template/syzoj/conteststatus.php
+++ b/trunk/web/template/syzoj/conteststatus.php
@@ -147,7 +147,8 @@
                 echo "'$result',";
         } ?>
         ''];
+        var oj_mark= <?php echo "'$OJ_MARK'";?>;
 </script>
-        <script src="template/bs3/auto_refresh.js?v=0.43" ></script>
+        <script src="template/syzoj/auto_refresh.js?v=0.43" ></script>
 
 <?php include("template/$OJ_TEMPLATE/footer.php");?>


### PR DESCRIPTION
此界面无法正确显示判题结果的原因是没有声明 oj_mark 变量，新增了 oj_mark 变量声明及赋值。