### PR TITLE
Fix fatal error: mysql/mysql.h

### DIFF
--- a/trunk/install/install-debian12.sh
+++ b/trunk/install/install-debian12.sh
@@ -7,7 +7,7 @@ cd /home/judge/
 wget -O hustoj.tar.gz http://dl.hustoj.com/hustoj.tar.gz
 tar xzf hustoj.tar.gz
 
-for PKG in make flex g++ clang mariadb-client libmysqlclient-dev libmysql++-dev memcached php-fpm php-memcached php-memcache nginx php-mysql php-common php-gd php-zip php-yaml fp-compiler openjdk-11-jdk mono-devel php-mbstring php-xml mariadb-server libmariadb-dev libmariadbclient-dev libmariadb-dev default-libmysqlclient-dev
+for PKG in make flex g++ clang mariadb-client libmariadb-dev libmariadb-dev-compat libmysql++-dev memcached php-fpm php-memcached php-memcache nginx php-mysql php-common php-gd php-zip php-yaml fp-compiler openjdk-17-jdk mono-devel php-mbstring php-xml mariadb-server libmariadbclient-dev default-libmysqlclient-dev
 do
    apt-get install -y $PKG 
 done


### PR DESCRIPTION
judged.cc:41:18: fatal error: mysql/mysql.h: No such file or directory
   41 |         #include <mysql/mysql.h>
      |                  ^~~~~~~~~~~~~~~
compilation terminated.
Fix this error.
Debian 12 default openjdk version changes to 17.