### PR TITLE
Remove SAE (Sina Cloud Engine) support

### DIFF
--- a/trunk/web/admin/help.php
+++ b/trunk/web/admin/help.php
@@ -207,7 +207,7 @@ $delay=pdo_query($sql);
   </tbody>
 </table>
 
-<?php if (isset($_SESSION[$OJ_NAME.'_'.'administrator'])&&!$OJ_SAE){?>
+<?php if (isset($_SESSION[$OJ_NAME.'_'.'administrator'])){?>
   <a href="problem_copy.php" target="main" title="Create your own data"><font color="eeeeee">CopyProblem</font></a> <br>
   <a href="problem_changeid.php" target="main" title="Danger,Use it on your own risk"><font color="eeeeee">ReOrderProblem</font></a>
   

--- a/trunk/web/admin/menu.php
+++ b/trunk/web/admin/menu.php
@@ -111,7 +111,7 @@ $OJ_TEMPLATE = "bs3";
             <a class='btn btn-sm' href="https://mp.weixin.qq.com/s?__biz=MzI1MTAwMTI2NA==&mid=2656403287&idx=1&sn=2b1b9a5cd0b271aa4a050c349981e715" target="_blank"><i class="glyphicon glyphicon-book-open"></i><b>二次开发教程</b></a><br>
         <?php }?>
 
-        <?php if (isset($_SESSION[$OJ_NAME.'_'.'administrator'])&&!$OJ_SAE){?>
+        <?php if (isset($_SESSION[$OJ_NAME.'_'.'administrator'])){?>
             <a href="solution_statistics.php" target="main" title="Create your own data"><i class="glyphicon glyphicon-chart-line"></i><font color="eeeeee">SS Report</font></a> <br>
             <a href="problem_copy.php" target="main" title="Create your own data"><i class="glyphicon glyphicon-copy"></i><font color="eeeeee">CopyProblem</font></a> <br>
             <a href="problem_changeid.php" target="main" title="Danger,Use it on your own risk"><i class="glyphicon glyphicon-exchange-alt"></i><font color="eeeeee">ReOrderProblem</font></a>

--- a/trunk/web/admin/offline_import.php
+++ b/trunk/web/admin/offline_import.php
@@ -76,7 +76,7 @@ function mkpta($pid,$prepends,$node) {
 
 
 function import_dir($json) {
-  global $OJ_DATA,$OJ_SAE,$OJ_REDIS,$OJ_REDISSERVER,$OJ_REDISPORT,$OJ_REDISQNAME,$domain,$DOMAIN;
+  global $OJ_DATA,$OJ_REDIS,$OJ_REDISSERVER,$OJ_REDISPORT,$OJ_REDISQNAME,$domain,$DOMAIN;
   $qduoj_problem=json_decode($json);
   echo( $qduoj_problem->{'problem'}->{'title'})."<br>";
 

--- a/trunk/web/admin/problem_changeid.php
+++ b/trunk/web/admin/problem_changeid.php
@@ -55,7 +55,6 @@ function writable($path){
 }
 
  $show_form=true;
-   if(!isset($OJ_SAE)||!$OJ_SAE){
 	   if(!writable($OJ_DATA)){
 		   echo " You need to add  $OJ_DATA into your open_basedir setting of php.ini,<br>
 					or you need to execute:<br>
@@ -63,7 +62,6 @@ function writable($path){
 					you can't use import function at this time.<br>"; 
 			$show_form=false;
 	   }
-	}	
 	if($show_form){
 ?>
 <b>Change ProblemID</b>

--- a/trunk/web/admin/problem_import.php
+++ b/trunk/web/admin/problem_import.php
@@ -51,16 +51,14 @@
   <div class="container">
     <?php 
     $show_form = true;
-    if (!isset($OJ_SAE) || !$OJ_SAE) {
-      if (!writable($OJ_DATA)) {
-        echo "<div class='alert alert-danger'>权限异常，请执行：<br><b>chmod 775 -R $OJ_DATA && chgrp -R ".get_current_user()." $OJ_DATA</b></div>";
-        $show_form = false;
-      }
-      if (!file_exists("../upload")) mkdir("../upload");
-      if (!writable("../upload")) {
-        echo "<div class='alert alert-danger'>../upload 目录不可写，请执行 <b>chmod 770 ../upload</b></div>";
-        $show_form = false;
-      }
+    if (!writable($OJ_DATA)) {
+      echo "<div class='alert alert-danger'>权限异常，请执行：<br><b>chmod 775 -R $OJ_DATA && chgrp -R ".get_current_user()." $OJ_DATA</b></div>";
+      $show_form = false;
+    }
+    if (!file_exists("../upload")) mkdir("../upload");
+    if (!writable("../upload")) {
+      echo "<div class='alert alert-danger'>../upload 目录不可写，请执行 <b>chmod 770 ../upload</b></div>";
+      $show_form = false;
     }
 
     if ($show_form) { ?>

--- a/trunk/web/admin/problem_import_hoj.php
+++ b/trunk/web/admin/problem_import_hoj.php
@@ -65,7 +65,7 @@ function get_extension($file) {
 }
 
 function import_json($json) {
-  global $OJ_DATA,$OJ_SAE,$OJ_REDIS,$OJ_REDISSERVER,$OJ_REDISPORT,$OJ_REDISQNAME,$domain,$DOMAIN;
+  global $OJ_DATA,$OJ_REDIS,$OJ_REDISSERVER,$OJ_REDISPORT,$OJ_REDISQNAME,$domain,$DOMAIN;
   $qduoj_problem=json_decode($json)->{'problem'};
  echo( "<br> ".$qduoj_problem->{'problemId'});
   echo( $qduoj_problem->{'title'})."<br>";

--- a/trunk/web/admin/problem_import_hydro.php
+++ b/trunk/web/admin/problem_import_hydro.php
@@ -114,7 +114,7 @@ function mkpta($pid,$prepends,$node) {
 
 
 function import_dir($json) {
-  global $OJ_DATA,$OJ_SAE,$OJ_REDIS,$OJ_REDISSERVER,$OJ_REDISPORT,$OJ_REDISQNAME,$domain,$DOMAIN,$_SESSION;
+  global $OJ_DATA,$OJ_REDIS,$OJ_REDISSERVER,$OJ_REDISPORT,$OJ_REDISQNAME,$domain,$DOMAIN,$_SESSION;
   $qduoj_problem=json_decode($json);
   echo( $qduoj_problem->{'problem'}->{'title'})."<br>";
 

--- a/trunk/web/admin/problem_import_md.php
+++ b/trunk/web/admin/problem_import_md.php
@@ -77,7 +77,7 @@ function mkpta($pid,$prepends,$node) {
 
 
 function import_dir($json) {
-  global $OJ_DATA,$OJ_SAE,$OJ_REDIS,$OJ_REDISSERVER,$OJ_REDISPORT,$OJ_REDISQNAME,$domain,$DOMAIN;
+  global $OJ_DATA,$OJ_REDIS,$OJ_REDISSERVER,$OJ_REDISPORT,$OJ_REDISQNAME,$domain,$DOMAIN;
   $qduoj_problem=json_decode($json);
   echo( $qduoj_problem->{'problem'}->{'title'})."<br>";
 

--- a/trunk/web/admin/problem_import_qduoj.php
+++ b/trunk/web/admin/problem_import_qduoj.php
@@ -65,7 +65,7 @@ function get_extension($file) {
 }
 
 function import_json($json) {
-  global $OJ_DATA,$OJ_SAE,$OJ_REDIS,$OJ_REDISSERVER,$OJ_REDISPORT,$OJ_REDISQNAME,$domain,$DOMAIN;
+  global $OJ_DATA,$OJ_REDIS,$OJ_REDISSERVER,$OJ_REDISPORT,$OJ_REDISQNAME,$domain,$DOMAIN;
   $qduoj_problem=json_decode($json);
   echo( $qduoj_problem->{'title'})."<br>";
   echo( $qduoj_problem->{'title'})."<br>";

--- a/trunk/web/admin/problem_import_tyvj.php
+++ b/trunk/web/admin/problem_import_tyvj.php
@@ -132,7 +132,7 @@ function get_extension($file) {
 }
 
 function import_fps($tempfile,$tempData) {
-  global $OJ_DATA,$OJ_SAE,$OJ_REDIS,$OJ_REDISSERVER,$OJ_REDISPORT,$OJ_REDISQNAME,$domain,$DOMAIN,$OJ_NAME;
+  global $OJ_DATA,$OJ_REDIS,$OJ_REDISSERVER,$OJ_REDISPORT,$OJ_REDISQNAME,$domain,$DOMAIN,$OJ_NAME;
   $xmlDoc = simplexml_load_file($tempfile, 'SimpleXMLElement', LIBXML_PARSEHUGE);
   $searchNodes = $xmlDoc->xpath("/DocumentElement");
   $spid = 0;
@@ -240,9 +240,7 @@ function import_fps($tempfile,$tempData) {
 	//新文件名
 	$new_file_name = date("YmdHis") . '_' . rand(10000, 99999) . '.' . $ext;
 	$newpath = $save_path."/$pid"."_".$testno."_".$new_file_name;
-         if ($OJ_SAE)
-            $newpath = "saestor://web/upload/".$newpath;
-	 else
+            $newpath="../upload/".$newpath;
             $newpath="../upload/".$newpath;
 		
           image_save_file($newpath,$base64);
@@ -261,7 +259,6 @@ function import_fps($tempfile,$tempData) {
         }
       }
 
-      if (!isset($OJ_SAE) || !$OJ_SAE) {
         if ($spj==1) {
 		if($spjcode){
 		  if($spjlang=="C++"){
@@ -307,7 +304,6 @@ function import_fps($tempfile,$tempData) {
 		  
 	  }
         }
-      }
 
       $solutions = $searchNode->children()->solution;
 

--- a/trunk/web/admin/problem_import_unkownoj.php
+++ b/trunk/web/admin/problem_import_unkownoj.php
@@ -65,7 +65,7 @@ function get_extension($file) {
 }
 
 function import_json($json) {
-  global $OJ_DATA,$OJ_SAE,$OJ_REDIS,$OJ_REDISSERVER,$OJ_REDISPORT,$OJ_REDISQNAME,$domain,$DOMAIN;
+  global $OJ_DATA,$OJ_REDIS,$OJ_REDISSERVER,$OJ_REDISPORT,$OJ_REDISQNAME,$domain,$DOMAIN;
   $qduoj_problem=json_decode($json);
   echo( $qduoj_problem->{'problem'}->{'title'})."<br>";
 

--- a/trunk/web/admin/problem_judge.php
+++ b/trunk/web/admin/problem_judge.php
@@ -209,22 +209,7 @@ if(isset($_POST['update_solution'])){
 
 	$pid=intval($_POST['pid']);
       
-  	if($OJ_SAE){
-          //echo $OJ_DATA."$pid";
-         
-           $store = new SaeStorage();
-           $ret = $store->getList("data", "$pid" ,100,0);
-            foreach($ret as $file) {
-              if(!strstr($file,"sae-dir-tag")){
-                     $file=pathinfo($file);
-                     $file=$file['basename'];
-                    		 echo $file."\n";   
-              }
-                    
-            }
-
-
-        } else{
+        {
         
             $dir=opendir($OJ_DATA."/$pid");
             while (($file = readdir($dir)) != ""){
@@ -244,16 +229,7 @@ if(isset($_POST['update_solution'])){
 	
 }else if(isset($_POST['gettestdata'])){
 	$file=$_POST['filename'];
-        if($OJ_SAE){ 
-		$store = new SaeStorage();
-                if($store->fileExists("data",$file)){
-                       
-                		echo $store->read("data",$file);
-                }
-                
-        }else{
-          	echo file_get_contents($OJ_DATA.'/'.$file);
-        }
+  echo file_get_contents($OJ_DATA.'/'.$file);
            
 }else{
 ?>

--- a/trunk/web/admin/setmsg.php
+++ b/trunk/web/admin/setmsg.php
@@ -6,7 +6,7 @@ if(!(isset($_SESSION[$OJ_NAME.'_'.'administrator']))){
 
 echo "<hr>";
 echo "<center><h3>".$MSG_NEWS."-".$MSG_SETMESSAGE."</h3></center>";
-$msgfile=$OJ_SAE?"saestor://web/msg.txt":"msg/$domain.txt";
+$msgfile="msg/".$domain.".txt";
 if(isset($_POST['do'])){
   require_once("../include/check_post_key.php");
   mkdir("msg");

--- a/trunk/web/include/db_info.inc.php
+++ b/trunk/web/include/db_info.inc.php
@@ -28,7 +28,6 @@ static  $OJ_LANGMASK=33554356; //掩码计算器:https://pigeon-developer.github
 static  $OJ_ACE_EDITOR=true;  // 是否启用有高亮提示的提交代码输入框
 static  $OJ_AUTO_SHARE=false; //true: 设为true则通过的题目可在统计页查看其他人代码.
 static  $OJ_CSS="white.css";  // bing.css | kawai.css | black.css | blue.css | green.css | hznu.css
-static  $OJ_SAE=false; //使用新浪引擎
 static  $OJ_VCODE=false;  //验证码
 static 	$OJ_REG_SPEED=60 ; //限制每小时同ip注册个数，0不限制
 static  $OJ_APPENDCODE=true;  // 代码预定模板

--- a/trunk/web/include/memcache.php
+++ b/trunk/web/include/memcache.php
@@ -5,11 +5,7 @@
     global $memcache;
     if ($OJ_MEMCACHE){
 	$memcache = new Memcache;
-		if($OJ_SAE){
-					$memcache=memcache_init();
-		}else{
 					@$memcache->connect($OJ_MEMSERVER,  $OJ_MEMPORT);
-		}
     }
 
     //下面两个函数首先都会判断是否有使用memcache，如果有使用，就会调用memcached的set/get命令来保存和获取数据

--- a/trunk/web/include/pdo.php
+++ b/trunk/web/include/pdo.php
@@ -5,7 +5,7 @@ function pdo_query($sql){
     $args = func_get_args();       //获得传入的所有参数的数组
     $args = array_slice($args,1,--$num_args);
     if(isset($args[0])&&is_array($args[0])) $args=$args[0]; 
-    global $DB_HOST,$DB_NAME,$DB_USER,$DB_PASS,$dbh,$OJ_SAE,$OJ_TEMPLATE;
+    global $DB_HOST,$DB_NAME,$DB_USER,$DB_PASS,$dbh,$OJ_TEMPLATE;
     try{
 	    if(!$dbh||stripos($sql,"create") === 0||stripos($sql,"drop") === 0|| stripos($sql,"grant") === 0){
 				

--- a/trunk/web/install.php
+++ b/trunk/web/install.php
@@ -25,7 +25,6 @@ function toName($k)
     $name["OJ_ACE_EDITOR"] = "代码高亮";
     $name["OJ_AUTO_SHARE"] = "代码共享";
     $name["OJ_CSS"] = "色系样式表";
-    $name["OJ_SAE"] = "新浪云";
     $name["OJ_VCODE"] = "验证码";
     $name["OJ_REG_SPEED"] = "注册速度限制";
     $name["OJ_APPENDCODE"] = "附加代码模式";

--- a/trunk/web/submit.php
+++ b/trunk/web/submit.php
@@ -477,11 +477,7 @@ $file = "cache/cache_$sid.html";
 if ($OJ_MEMCACHE) {
     $mem = new Memcache();
 
-    if ($OJ_SAE) {
-        $mem = memcache_init();
-    } else {
         $mem->connect($OJ_MEMSERVER, $OJ_MEMPORT);
-    }
 
     $mem->delete($file, 0);
 } elseif (file_exists($file)) {

--- a/trunk/web/template/sidebar/js.php
+++ b/trunk/web/template/sidebar/js.php
@@ -2,7 +2,7 @@
 <?php
 $msg_path=realpath(dirname(__FILE__)."/../../admin/msg/$domain.txt");
 if(file_exists($msg_path))
-	$view_marquee_msg=file_get_contents($OJ_SAE?"saestor://web/msg.txt":$msg_path);
+	$view_marquee_msg=file_get_contents($msg_path);
 else
 	$view_marquee_msg="";
 

--- a/trunk/web/template/sweet/js.php
+++ b/trunk/web/template/sweet/js.php
@@ -15,7 +15,7 @@
 
 <?php
 if(file_exists("./admin/msg/$domain.txt"))
-      $view_marquee_msg=file_get_contents($OJ_SAE?"saestor://web/msg.txt":"./admin/msg/$domain.txt");
+      $view_marquee_msg=file_get_contents("./admin/msg/$domain.txt");
 
 
 ?>

--- a/trunk/web/template/syzoj/js.php
+++ b/trunk/web/template/syzoj/js.php
@@ -2,7 +2,7 @@
 <?php
 $msg_path=realpath(dirname(__FILE__)."/../../admin/msg/$domain.txt");
 if(file_exists($msg_path))
-	$view_marquee_msg=file_get_contents($OJ_SAE?"saestor://web/msg.txt":$msg_path);
+	$view_marquee_msg=file_get_contents($msg_path);
 else
 	$view_marquee_msg="";
 


### PR DESCRIPTION
SAE has been discontinued. Remove all SAE-specific code branches:
- Remove SaeStorage usage in problem_judge.php
- Remove SAE MySQL/PDO connection in pdo.php
- Remove SAE memcache_init() in memcache.php and submit.php
- Remove $OJ_SAE config and install option
- Remove ternary operators for saestor:// paths in templates
- Remove global $OJ_SAE from import/admin files
- Remove &&!$OJ_SAE admin menu conditions
- Remove problem_export_xml.php deletion (restored from origin