### PR TITLE
Fix Safari crash caused by SVG backdrop filter

### DIFF
--- a/trunk/web/template/sidebar/css.php
+++ b/trunk/web/template/sidebar/css.php
@@ -3,18 +3,6 @@
         if( $OJ_CDN_URL=="" && ($dir=="discuss3"||$dir=="admin"||$dir=="include")) $path_fix="../";
         else $path_fix="";
 ?>
-<!-- 苹果液体玻璃效果所需SVG滤镜 -->
-<svg xmlns="http://www.w3.org/2000/svg" style="display: none;">
-  <filter id="customLensFilter" x="0%" y="0%" width="100%" height="100%" filterUnits="objectBoundingBox">
-    <feComponentTransfer in="SourceAlpha" result="alpha">
-      <feFuncA type="identity" />
-    </feComponentTransfer>
-    <feGaussianBlur in="alpha" stdDeviation="50" result="blur" />
-    <feDisplacementMap in="SourceGraphic" in2="blur" scale="50" xChannelSelector="A" yChannelSelector="A" />
-  </filter>
-</svg>
-<!-- 玻璃效果样式 - 整合到.padding类中 -->
-
 <link rel="stylesheet" href="<?php echo $OJ_CDN_URL.$path_fix."template/$OJ_TEMPLATE"?>/css/style.css">
 <link rel="stylesheet" href="<?php echo $OJ_CDN_URL.$path_fix."template/$OJ_TEMPLATE"?>/css/tomorrow.css">
 <link rel="stylesheet" href="<?php echo $OJ_CDN_URL.$path_fix."template/$OJ_TEMPLATE"?>/css/semantic.min.css?v=0.1">
@@ -31,4 +19,3 @@
 <?php if (file_exists(dirname(__FILE__)."/$OJ_CSS")){ ?>
 <link href="<?php echo $path_fix."template/$OJ_TEMPLATE"?>/<?php echo $OJ_CSS?>?v=0.1" rel="stylesheet">
 <?php } ?>
-

--- a/trunk/web/template/sidebar/css/white.css
+++ b/trunk/web/template/sidebar/css/white.css
@@ -27,8 +27,9 @@
 .padding::before {
 
   z-index: -2;
+  -webkit-backdrop-filter: blur(4px);
   backdrop-filter: blur(4px);
-  filter: url(#customLensFilter) saturate(120%) brightness(1.15);
+  filter: saturate(120%) brightness(1.15);
 
 }
 .padding::after {

--- a/trunk/web/template/syzoj/css.php
+++ b/trunk/web/template/syzoj/css.php
@@ -3,18 +3,6 @@
         if( $OJ_CDN_URL=="" && ($dir=="discuss3"||$dir=="admin"||$dir=="include")) $path_fix="../";
         else $path_fix="";
 ?>
-<!-- 苹果液体玻璃效果所需SVG滤镜 -->
-<svg xmlns="http://www.w3.org/2000/svg" style="display: none;">
-  <filter id="customLensFilter" x="0%" y="0%" width="100%" height="100%" filterUnits="objectBoundingBox">
-    <feComponentTransfer in="SourceAlpha" result="alpha">
-      <feFuncA type="identity" />
-    </feComponentTransfer>
-    <feGaussianBlur in="alpha" stdDeviation="50" result="blur" />
-    <feDisplacementMap in="SourceGraphic" in2="blur" scale="50" xChannelSelector="A" yChannelSelector="A" />
-  </filter>
-</svg>
-<!-- 玻璃效果样式 - 整合到.padding类中 -->
-
 <link rel="stylesheet" href="<?php echo $OJ_CDN_URL.$path_fix."template/$OJ_TEMPLATE"?>/css/style.css">
 <link rel="stylesheet" href="<?php echo $OJ_CDN_URL.$path_fix."template/$OJ_TEMPLATE"?>/css/tomorrow.css">
 <link rel="stylesheet" href="<?php echo $OJ_CDN_URL.$path_fix."template/$OJ_TEMPLATE"?>/css/semantic.min.css?v=0.1">
@@ -31,4 +19,3 @@
 <?php if (file_exists(dirname(__FILE__)."/$OJ_CSS")){ ?>
 <link href="<?php echo $path_fix."template/$OJ_TEMPLATE"?>/<?php echo $OJ_CSS?>?v=0.1" rel="stylesheet">
 <?php } ?>
-

--- a/trunk/web/template/syzoj/css/white.css
+++ b/trunk/web/template/syzoj/css/white.css
@@ -27,8 +27,9 @@
 .padding::before {
 
   z-index: -2;
+  -webkit-backdrop-filter: blur(4px);
   backdrop-filter: blur(4px);
-  filter: url(#customLensFilter) saturate(120%) brightness(1.15);
+  filter: saturate(120%) brightness(1.15);
 
 }
 .padding::after {


### PR DESCRIPTION
## Problem

The SVG filter used by the syzoj/sidebar white theme crashes Safari 27 Beta with:

```
RemoteGraphicsContext_DrawFilteredImageBuffer
reason=RequestedByGPUProcess
```

## Changes

- Remove the `customLensFilter` SVG and its `url(...)` reference.
- Keep the existing blur, saturation, and brightness effects.
- Add `-webkit-backdrop-filter` for Safari compatibility.
- Apply the same change to both syzoj and sidebar templates.

## Verification

Tested the real homepage successfully in Safari 27 Beta, Chrome, and Firefox. Safari no longer terminates the WebContent process.