### PR TITLE
fix: the weibo oauth login handler sets session user... in...

### DIFF
--- a/trunk/web/login_weibo.php
+++ b/trunk/web/login_weibo.php
@@ -65,6 +65,7 @@ if (isset($_GET['code'])) {
             pdo_query($sql, $uname, $email, $ip, $password, $nick, $school);
         }
         // login it
+        session_regenerate_id(true);
         $_SESSION[$OJ_NAME . '_' . 'user_id'] = $uname;
         // redirect it
         header("Location: ./");


### PR DESCRIPTION
## Summary
Fix high severity security issue in `trunk/web/login_weibo.php`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-002 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-002` |
| **File** | `trunk/web/login_weibo.php:47` |
| **Assessment** | Likely exploitable |
| **Chain Complexity** | 3-step |

**Description**: The Weibo OAuth login handler sets session user_id without calling session_regenerate_id(), reusing the pre-authentication session ID. This makes the application vulnerable to session fixation attacks where an attacker can hijack authenticated sessions.

## Evidence

**Exploitation scenario**: Attacker sets victim's PHP session cookie before authentication via subdomain cookie injection or MITM.

**Scanner confirmation**: multi_agent_ai rule `V-002` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Threat Model Context

This is a containerized service - vulnerabilities may be exploitable depending on network exposure.

## Changes
- `trunk/web/login_weibo.php`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path, and the project's existing tests still pass, so intended behavior is unchanged.

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
