### PR TITLE
fix: the docker/setup in setup.sh

### DIFF
--- a/docker/setup.sh
+++ b/docker/setup.sh
@@ -6,7 +6,10 @@ chown -R mysql:mysql /var/run/mysqld
 chmod -R 755         /var/run/mysqld
 service mysql start
 mysql < /trunk/install/db.sql
+ADMIN_PASSWORD=`openssl rand -base64 12`
+mysql -e "insert into jol.users (user_id,password,nick,reg_time) values('admin', md5('$ADMIN_PASSWORD'), 'admin', now());"
 mysql -e "insert into jol.privilege ( user_id, rightstr ) values('admin','administrator');"
+echo "Generated initial admin password (change after first login): $ADMIN_PASSWORD"
 mysql -e "insert into jol.problem(problem_id,title,time_limit,memory_limit,defunct) values(1000,1,1,5,'N');"
 mysql -e "insert into jol.source_code values(1,'#include<stdio.h>\nint main(){\nint a,b;\nscanf(\"%d%d\",&a,&b);\nprintf(\"%d\\\\n\",a+b);\n}\n');"
 mysql -e "insert into jol.solution (solution_id,user_id,problem_id,ip,in_date) values(1,'1',1000,'127.0.0.1',now());"


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `docker/setup.sh`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `docker/setup.sh:9` |
| **Assessment** | Likely exploitable |

**Description**: The docker/setup.sh script creates an admin account with a hardcoded username 'admin' that automatically receives administrator privileges. The first user to register with username 'admin' gains full administrative access to the judge system without any password verification or additional authentication.

## Evidence

**Exploitation scenario**: An attacker simply registers a new account with username 'admin' before the legitimate administrator.

**Scanner confirmation**: multi_agent_ai rule `V-001` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Threat Model Context

This is a containerized service - vulnerabilities may be exploitable depending on network exposure.

## Changes
- `docker/setup.sh`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path.

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*

<!-- orbis-meta: rule=V-001 scanner=multi_agent_ai -->
